### PR TITLE
Update vault dependency with go mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/hashicorp/go-sockaddr v1.0.2
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/hashicorp/serf v0.9.2 // indirect
-	github.com/hashicorp/vault/api v1.0.5-0.20190730042357-746c0b111519
+	github.com/hashicorp/vault/api v1.5.0
 	github.com/mitchellh/mapstructure v1.3.0 // indirect
 	github.com/pierrec/lz4 v2.5.2+incompatible // indirect
 	github.com/pkg/errors v0.9.1


### PR DESCRIPTION
The current vault version is pre-go-mod and causes ambiguous import when using hcat in a different project. [v1.2.0](https://github.com/hashicorp/vault/blob/master/CHANGELOG.md#120-july-30th-2019) is the first version to introduce go modules. Proposing to update to v1.5.0 so the library has the latest vault API

```
$ go version
go version go1.14.6 darwin/amd64
```

```
$ go build .
../../go/pkg/mod/github.com/hashicorp/hcat@v0.0.0-20200720224533-277e95c9cdfd/internal/dependency/client_set.go:13:2: ambiguous import: found package github.com/hashicorp/vault/api in multiple modules:
	github.com/hashicorp/vault v0.10.4 (${GOPATH}/pkg/mod/github.com/hashicorp/vault@v0.10.4/api)
	github.com/hashicorp/vault/api v1.0.5-0.20190730042357-746c0b111519 (${GOPATH}/pkg/mod/github.com/hashicorp/vault/api@v1.0.5-0.20190730042357-746c0b111519)
```

```
$ go mod why
github.com/hashicorp/${PROJ}/${PKG} imports
	github.com/hashicorp/hcat imports
	github.com/hashicorp/hcat/internal/dependency imports
	github.com/hashicorp/vault/api: ambiguous import: found github.com/hashicorp/vault/api in multiple modules:
	github.com/hashicorp/vault v0.10.4 (${GOPATH}/pkg/mod/github.com/hashicorp/vault@v0.10.4/api)
	github.com/hashicorp/vault/api v1.0.5-0.20190730042357-746c0b111519 (${GOPATH}/pkg/mod/github.com/hashicorp/vault/api@v1.0.5-0.20190730042357-746c0b111519)
```