### PR TITLE
Include datacenter and namespace to health service

### DIFF
--- a/internal/dependency/catalog_service.go
+++ b/internal/dependency/catalog_service.go
@@ -36,6 +36,7 @@ type CatalogService struct {
 	ServiceTags     ServiceTags
 	ServiceMeta     map[string]string
 	ServicePort     int
+	Namespace       string
 }
 
 // CatalogServiceQuery is the representation of a requested catalog services
@@ -114,6 +115,7 @@ func (d *CatalogServiceQuery) Fetch(clients dep.Clients) (interface{}, *dep.Resp
 			ServiceTags:     ServiceTags(deepCopyAndSortTags(s.ServiceTags)),
 			ServiceMeta:     s.ServiceMeta,
 			ServicePort:     s.ServicePort,
+			Namespace:       s.Namespace,
 		})
 	}
 

--- a/internal/dependency/health_service.go
+++ b/internal/dependency/health_service.go
@@ -41,6 +41,7 @@ type HealthService struct {
 	Node                string
 	NodeID              string
 	NodeAddress         string
+	NodeDatacenter      string
 	NodeTaggedAddresses map[string]string
 	NodeMeta            map[string]string
 	ServiceMeta         map[string]string
@@ -52,6 +53,7 @@ type HealthService struct {
 	Status              string
 	Port                int
 	Weights             api.AgentWeights
+	Namespace           string
 }
 
 // HealthServiceQuery is the representation of all a service query in Consul.
@@ -182,6 +184,7 @@ func (d *HealthServiceQuery) Fetch(clients dep.Clients) (interface{}, *dep.Respo
 			Node:                entry.Node.Node,
 			NodeID:              entry.Node.ID,
 			NodeAddress:         entry.Node.Address,
+			NodeDatacenter:      entry.Node.Datacenter,
 			NodeTaggedAddresses: entry.Node.TaggedAddresses,
 			NodeMeta:            entry.Node.Meta,
 			ServiceMeta:         entry.Service.Meta,
@@ -190,10 +193,11 @@ func (d *HealthServiceQuery) Fetch(clients dep.Clients) (interface{}, *dep.Respo
 			Name:                entry.Service.Service,
 			Tags: ServiceTags(
 				deepCopyAndSortTags(entry.Service.Tags)),
-			Status:  status,
-			Checks:  entry.Checks,
-			Port:    entry.Service.Port,
-			Weights: entry.Service.Weights,
+			Status:    status,
+			Checks:    entry.Checks,
+			Port:      entry.Service.Port,
+			Weights:   entry.Service.Weights,
+			Namespace: entry.Service.Namespace,
 		})
 	}
 

--- a/internal/dependency/health_service_test.go
+++ b/internal/dependency/health_service_test.go
@@ -173,19 +173,21 @@ func TestHealthConnectServiceQuery_Fetch(t *testing.T) {
 			"foo",
 			[]*HealthService{
 				&HealthService{
-					Name:        "foo-sidecar-proxy",
-					ID:          "foo",
-					Port:        21999,
-					Status:      "passing",
-					Address:     "127.0.0.1",
-					NodeAddress: "127.0.0.1",
-					Tags:        ServiceTags([]string{}),
+					Name:           "foo-sidecar-proxy",
+					ID:             "foo",
+					Port:           21999,
+					Status:         "passing",
+					Address:        "127.0.0.1",
+					NodeAddress:    "127.0.0.1",
+					NodeDatacenter: "dc1",
+					Tags:           ServiceTags([]string{}),
 					NodeMeta: map[string]string{
 						"consul-network-segment": ""},
 					Weights: api.AgentWeights{
 						Passing: 1,
 						Warning: 1,
 					},
+					Namespace: "",
 				},
 			},
 		},
@@ -231,8 +233,9 @@ func TestHealthServiceQuery_Fetch(t *testing.T) {
 			"consul",
 			[]*HealthService{
 				&HealthService{
-					Node:        testConsul.Config.NodeName,
-					NodeAddress: testConsul.Config.Bind,
+					Node:           testConsul.Config.NodeName,
+					NodeAddress:    testConsul.Config.Bind,
+					NodeDatacenter: "dc1",
 					NodeTaggedAddresses: map[string]string{
 						"lan": "127.0.0.1",
 						"wan": "127.0.0.1",
@@ -251,6 +254,7 @@ func TestHealthServiceQuery_Fetch(t *testing.T) {
 						Passing: 1,
 						Warning: 1,
 					},
+					Namespace: "",
 				},
 			},
 		},
@@ -264,8 +268,9 @@ func TestHealthServiceQuery_Fetch(t *testing.T) {
 			"consul|warning,passing",
 			[]*HealthService{
 				&HealthService{
-					Node:        testConsul.Config.NodeName,
-					NodeAddress: testConsul.Config.Bind,
+					Node:           testConsul.Config.NodeName,
+					NodeAddress:    testConsul.Config.Bind,
+					NodeDatacenter: "dc1",
 					NodeTaggedAddresses: map[string]string{
 						"lan": "127.0.0.1",
 						"wan": "127.0.0.1",
@@ -284,6 +289,7 @@ func TestHealthServiceQuery_Fetch(t *testing.T) {
 						Passing: 1,
 						Warning: 1,
 					},
+					Namespace: "",
 				},
 			},
 		},
@@ -292,8 +298,9 @@ func TestHealthServiceQuery_Fetch(t *testing.T) {
 			"service-meta",
 			[]*HealthService{
 				&HealthService{
-					Node:        testConsul.Config.NodeName,
-					NodeAddress: testConsul.Config.Bind,
+					Node:           testConsul.Config.NodeName,
+					NodeAddress:    testConsul.Config.Bind,
+					NodeDatacenter: "dc1",
 					NodeTaggedAddresses: map[string]string{
 						"lan": "127.0.0.1",
 						"wan": "127.0.0.1",
@@ -313,6 +320,7 @@ func TestHealthServiceQuery_Fetch(t *testing.T) {
 						Passing: 1,
 						Warning: 1,
 					},
+					Namespace: "",
 				},
 			},
 		},


### PR DESCRIPTION
This adds the service attribute `namespace` and and `node_datacenter` to the `HealthService` object and `namespace` to `CatalogService` object. These attributes are now accessible in templates.

```
{{- range service "web" }}
{{.Name}} {{.Namespace}} {{.NodeDatacenter}}
{{- end }}
```

Note that namespace is an enterprise feature and will return an empty string for services.