### PR TITLE
Add context to Watcher.Wait to be cancellable before timeout

### DIFF
--- a/doc_test.go
+++ b/doc_test.go
@@ -45,7 +45,7 @@ func RenderExampleOnce(addr string) string {
 			return string(re.Contents)
 		}
 		// Wait pauses until new data has been received
-		err = w.Wait(ctx, 0) // 0 == no timeout
+		err = w.Wait(ctx)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -67,7 +67,7 @@ func RenderMultipleOnce(addr string) string {
 		Cache:   NewStore(),
 	})
 
-	ctx := context.Background()
+	ctx, _ := context.WithTimeout(context.Background(), time.Second)
 	results := []string{}
 	r := NewResolver()
 	for {
@@ -84,7 +84,7 @@ func RenderMultipleOnce(addr string) string {
 			break
 		}
 		// Wait pauses until new data has been received
-		err := w.Wait(ctx, time.Second)
+		err := w.Wait(ctx)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/doc_test.go
+++ b/doc_test.go
@@ -1,6 +1,7 @@
 package hcat
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"strings"
@@ -33,6 +34,7 @@ func RenderExampleOnce(addr string) string {
 		Cache:   NewStore(),
 	})
 
+	ctx := context.Background()
 	r := NewResolver()
 	for {
 		re, err := r.Run(tmpl, w)
@@ -43,7 +45,7 @@ func RenderExampleOnce(addr string) string {
 			return string(re.Contents)
 		}
 		// Wait pauses until new data has been received
-		err = w.Wait(0) // 0 == no timeout
+		err = w.Wait(ctx, 0) // 0 == no timeout
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -65,6 +67,7 @@ func RenderMultipleOnce(addr string) string {
 		Cache:   NewStore(),
 	})
 
+	ctx := context.Background()
 	results := []string{}
 	r := NewResolver()
 	for {
@@ -81,7 +84,7 @@ func RenderMultipleOnce(addr string) string {
 			break
 		}
 		// Wait pauses until new data has been received
-		err := w.Wait(time.Second)
+		err := w.Wait(ctx, time.Second)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/resolver.go
+++ b/resolver.go
@@ -2,12 +2,12 @@ package hcat
 
 import "github.com/hashicorp/hcat/dep"
 
-// Runner responsible rendering Templates and invoking Commands.
+// Resolver is responsible rendering Templates and invoking Commands.
 // Empty but reserving the space for future use.
 type Resolver struct{}
 
-// RenderEvent captures the time and events that occurred for a template
-// rendering.
+// ResolveEvent captures the whether the template dependencies have all been
+// resolved and rendered in memory.
 type ResolveEvent struct {
 	// Complete is true if all dependencies have values and the template
 	// is is fully rendered.

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -1,6 +1,7 @@
 package hcat
 
 import (
+	"context"
 	"strings"
 	"testing"
 	"text/template"
@@ -91,7 +92,8 @@ func TestResolverRun(t *testing.T) {
 		if r.missing == false {
 			t.Fatal("missing should be true")
 		}
-		w.Wait(0) // wait for (fake/instantaneous) dependency resolution
+		ctx := context.Background()
+		w.Wait(ctx, 0) // wait for (fake/instantaneous) dependency resolution
 
 		r, err = rv.Run(tt, w)
 		if err != nil {
@@ -124,7 +126,8 @@ func TestResolverRun(t *testing.T) {
 		if r.missing == false {
 			t.Fatal("missing should be true")
 		}
-		w.Wait(0) // wait for (fake/instantaneous) dependency resolution
+		ctx := context.Background()
+		w.Wait(ctx, 0) // wait for (fake/instantaneous) dependency resolution
 
 		// Run 2, 'echo foo' is missing
 		r, err = rv.Run(tt, w)
@@ -134,7 +137,7 @@ func TestResolverRun(t *testing.T) {
 		if r.missing == false {
 			t.Fatal("missing should be true")
 		}
-		w.Wait(0)
+		w.Wait(ctx, 0)
 
 		// Run 3, 'echo bar' is missing
 		r, err = rv.Run(tt, w)
@@ -144,7 +147,7 @@ func TestResolverRun(t *testing.T) {
 		if r.missing == false {
 			t.Fatal("missing should be true")
 		}
-		w.Wait(0)
+		w.Wait(ctx, 0)
 
 		// Run 4, complete
 		r, err = rv.Run(tt, w)

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -93,7 +93,7 @@ func TestResolverRun(t *testing.T) {
 			t.Fatal("missing should be true")
 		}
 		ctx := context.Background()
-		w.Wait(ctx, 0) // wait for (fake/instantaneous) dependency resolution
+		w.Wait(ctx) // wait for (fake/instantaneous) dependency resolution
 
 		r, err = rv.Run(tt, w)
 		if err != nil {
@@ -127,7 +127,7 @@ func TestResolverRun(t *testing.T) {
 			t.Fatal("missing should be true")
 		}
 		ctx := context.Background()
-		w.Wait(ctx, 0) // wait for (fake/instantaneous) dependency resolution
+		w.Wait(ctx) // wait for (fake/instantaneous) dependency resolution
 
 		// Run 2, 'echo foo' is missing
 		r, err = rv.Run(tt, w)
@@ -137,7 +137,7 @@ func TestResolverRun(t *testing.T) {
 		if r.missing == false {
 			t.Fatal("missing should be true")
 		}
-		w.Wait(ctx, 0)
+		w.Wait(ctx)
 
 		// Run 3, 'echo bar' is missing
 		r, err = rv.Run(tt, w)
@@ -147,7 +147,7 @@ func TestResolverRun(t *testing.T) {
 		if r.missing == false {
 			t.Fatal("missing should be true")
 		}
-		w.Wait(ctx, 0)
+		w.Wait(ctx)
 
 		// Run 4, complete
 		r, err = rv.Run(tt, w)

--- a/watcher_test.go
+++ b/watcher_test.go
@@ -1,6 +1,7 @@
 package hcat
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"testing"
@@ -182,7 +183,7 @@ func TestWatcherWait(t *testing.T) {
 		w := newWatcher(t)
 		defer w.Stop()
 		t1 := time.Now()
-		err := w.Wait(time.Microsecond * 100)
+		err := w.Wait(context.Background(), time.Microsecond*100)
 		if err != nil {
 			t.Fatal("Error not expected")
 		}
@@ -200,7 +201,7 @@ func TestWatcherWait(t *testing.T) {
 			time.Sleep(time.Microsecond * 100)
 			w.errCh <- testerr
 		}()
-		w.Wait(0)
+		w.Wait(context.Background(), 0)
 		dur := time.Now().Sub(t1)
 		if dur < time.Microsecond*100 || dur > time.Millisecond*10 {
 			t.Fatal("Wait call was off;", dur)
@@ -213,7 +214,7 @@ func TestWatcherWait(t *testing.T) {
 		go func() {
 			w.errCh <- testerr
 		}()
-		err := w.Wait(0)
+		err := w.Wait(context.Background(), 0)
 		if err != testerr {
 			t.Fatal("None or Unexpected Error;", err)
 		}
@@ -240,7 +241,7 @@ func TestWatcherWait(t *testing.T) {
 			Dependency: foodep,
 		})
 		w.dataCh <- view
-		w.Wait(0)
+		w.Wait(context.Background(), 0)
 		store := w.cache.(*Store)
 		if _, ok := store.data[foodep.String()]; !ok {
 			t.Fatal("failed update")
@@ -262,7 +263,7 @@ func TestWatcherWait(t *testing.T) {
 				w.dataCh <- v
 			}
 		}()
-		w.Wait(0)
+		w.Wait(context.Background(), 0)
 		store := w.cache.(*Store)
 		if len(store.data) != 5 {
 			t.Fatal("failed update")
@@ -280,7 +281,7 @@ func TestWatcherWait(t *testing.T) {
 			Dependency: foodep,
 		})
 		w.dataCh <- view
-		w.Wait(0)
+		w.Wait(context.Background(), 0)
 		if w.changed.Len() != 1 {
 			t.Fatal("failed to track updated dependency")
 		}
@@ -301,7 +302,7 @@ func TestWatcherWait(t *testing.T) {
 				w.dataCh <- v
 			}
 		}()
-		w.Wait(0)
+		w.Wait(context.Background(), 0)
 		if w.changed.Len() != 5 {
 			t.Fatal("failed to track updated dependency")
 		}
@@ -316,7 +317,7 @@ func TestWatcherWait(t *testing.T) {
 			})
 			w.dataCh <- view
 		}
-		w.Wait(0)
+		w.Wait(context.Background(), 0)
 		if w.changed.Len() != 1 {
 			t.Fatal("failed to track updated dependency")
 		}
@@ -329,7 +330,7 @@ func TestWatcherWait(t *testing.T) {
 			Dependency: foodep,
 		})
 		w.dataCh <- view
-		err := <-w.WaitCh(0)
+		err := <-w.WaitCh(context.Background(), 0)
 		if err != nil {
 			t.Fatal("wait error:", err)
 		}


### PR DESCRIPTION
When a caller attempts to shutdown or needs to interrupt `watcher.Wait`, it would require waiting the full `timeout` duration. PR adds context handling for the caller to cancel if needed.