### PR TITLE
Add configurable buffering period for templates

### DIFF
--- a/buffer_period.go
+++ b/buffer_period.go
@@ -1,0 +1,181 @@
+package hcat
+
+import (
+	"sync"
+	"time"
+)
+
+// timers is a threadsafe object to manage multiple timers that represent
+// buffer periods for objects by their ID.
+type timers struct {
+	// timers is the map of IDs to their active buffer timers.
+	timers   map[string]*timer
+	buffered map[string]bool
+	ch       chan string
+	mux      sync.RWMutex
+}
+
+// timer is an internal representation of a single buffer state.
+type timer struct {
+	id       string
+	min      time.Duration
+	max      time.Duration
+	ch       chan string
+	timer    *time.Timer
+	deadline time.Time
+
+	isActive bool
+	mux      sync.RWMutex
+}
+
+func newTimers() *timers {
+	return &timers{
+		timers:   make(map[string]*timer),
+		buffered: make(map[string]bool),
+		ch:       make(chan string, 10),
+	}
+}
+
+// Run is a blocking function to monitor timers and notify the channel
+// a buffer period has completed.
+func (t *timers) Run(triggerCh chan string) {
+	for {
+		id, ok := <-t.ch
+		if !ok {
+			return
+		}
+		t.mux.Lock()
+		t.buffered[id] = true
+		t.mux.Unlock()
+		triggerCh <- id
+	}
+}
+
+// Stop sends a signal to halt monitoring of timers and clears out any active
+// timers.
+func (t *timers) Stop() {
+	t.mux.Lock()
+	defer t.mux.Unlock()
+
+	for id, timer := range t.timers {
+		timer.timer.Stop()
+		delete(t.timers, id)
+	}
+
+	// Close the channel after stopping timers to avoid timers writing to a
+	// closed channel.
+	close(t.ch)
+}
+
+// Add a new timer and returns if the timer was added.
+func (t *timers) Add(min, max time.Duration, id string) bool {
+	t.mux.Lock()
+	defer t.mux.Unlock()
+
+	if t.timers[id] != nil {
+		return false
+	}
+
+	t.timers[id] = newTimer(t.ch, min, max, id)
+	return true
+}
+
+// Buffered checks the cache of recently expired timers if the timer is done
+// buffering.
+func (t *timers) Buffered(id string) bool {
+	t.mux.RLock()
+	defer t.mux.RUnlock()
+	return t.buffered[id]
+}
+
+// Buffer activates the buffer period and updates the timer. Returns whether
+// the buffer is already active.
+func (t *timers) Buffer(id string) bool {
+	t.mux.Lock()
+	defer t.mux.Unlock()
+
+	if t.buffered[id] {
+		// Buffer is being reactivated, remove it from the cache because it's no
+		// longer considered ready.
+		delete(t.buffered, id)
+		return false
+	}
+
+	timer, ok := t.timers[id]
+	if ok {
+		return timer.tick()
+	}
+	return false
+}
+
+// newTimer creates a new buffer timer for the given template.
+func newTimer(ch chan string, min, max time.Duration, id string) *timer {
+	return &timer{
+		id:  id,
+		min: min,
+		max: max,
+		ch:  ch,
+	}
+}
+
+// tick updates the minimum buffer timer and returns whether the timer
+// was active.
+func (t *timer) tick() bool {
+	now := time.Now()
+
+	if t.active() {
+		t.activeTick(now)
+		return true
+	}
+
+	t.inactiveTick(now)
+	return false
+}
+
+func (t *timer) active() bool {
+	t.mux.RLock()
+	defer t.mux.RUnlock()
+	return t.isActive
+}
+
+// inactiveTick is the first tick of a buffer period, set up the timer and
+// calculate the max deadline.
+func (t *timer) inactiveTick(now time.Time) {
+	if t.timer == nil {
+		t.timer = time.NewTimer(t.min)
+	} else {
+		t.timer.Reset(t.min)
+	}
+
+	t.mux.Lock()
+	t.isActive = true
+	t.deadline = now.Add(t.max) // reset the deadline ot the future
+	t.mux.Unlock()
+
+	go func() {
+		<-t.timer.C
+		t.mux.Lock()
+		t.ch <- t.id
+		t.isActive = false
+		t.mux.Unlock()
+	}()
+}
+
+// activeTick snoozes the timer for the min time, or snooze less if we are coming
+// up against the max time.
+func (t *timer) activeTick(now time.Time) {
+	// Wait for the lock in case the go routine is updating the active state.
+	// If the timer has already fired don't snooze and let the next tick reset
+	// the buffer period to active
+	t.mux.Lock()
+	defer t.mux.Unlock()
+	if !t.isActive {
+		return
+	}
+
+	if now.Add(t.min).Before(t.deadline) {
+		t.timer.Reset(t.min)
+	} else if dur := t.deadline.Sub(now); dur > 0 {
+		t.timer.Reset(dur)
+	}
+}

--- a/buffer_period.go
+++ b/buffer_period.go
@@ -61,10 +61,6 @@ func (t *timers) Stop() {
 		timer.timer.Stop()
 		delete(t.timers, id)
 	}
-
-	// Close the channel after stopping timers to avoid timers writing to a
-	// closed channel.
-	close(t.ch)
 }
 
 // Add a new timer and returns if the timer was added.

--- a/buffer_period_test.go
+++ b/buffer_period_test.go
@@ -1,0 +1,93 @@
+package hcat
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBufferPeriod(t *testing.T) {
+	testCases := []struct {
+		name           string
+		min            time.Duration
+		max            time.Duration
+		snoozeCount    int64
+		snoozeAfter    time.Duration
+		expectedWithin time.Duration
+	}{
+		{
+			name: "one period",
+			min:  time.Duration(2 * time.Second),
+			max:  time.Duration(10 * time.Second),
+		},
+		{
+			name:        "snooze once",
+			min:         time.Duration(4 * time.Second),
+			max:         time.Duration(12 * time.Second),
+			snoozeCount: 1,
+			snoozeAfter: time.Duration(1 * time.Second),
+		},
+		{
+			name:        "deadline",
+			min:         time.Duration(4 * time.Second),
+			max:         time.Duration(6 * time.Second),
+			snoozeCount: 3,
+			snoozeAfter: time.Duration(1 * time.Second),
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			tc := testCase
+			t.Parallel()
+			expectedWithin := tc.min + time.Duration(tc.snoozeCount)*tc.snoozeAfter + time.Second
+
+			triggerCh := make(chan string)
+			bufferPeriods := newTimers()
+			go bufferPeriods.Run(triggerCh)
+			defer bufferPeriods.Stop()
+
+			bufferPeriods.Add(tc.min, tc.max, tc.name)
+			assert.False(t, bufferPeriods.Buffered(tc.name), "buffer isn't activated yet to be buffered")
+
+			active := bufferPeriods.Buffer(tc.name)
+			assert.False(t, active, "buffer is unexpectedly already active")
+
+			// Simulate consecutive calls to resolver.Run(template)
+			go func() {
+				for i := int64(0); i < tc.snoozeCount; i++ {
+					<-time.After(tc.snoozeAfter * time.Second)
+					bufferPeriods.Buffer(tc.name)
+				}
+			}()
+
+			// Test signal is received within expected duration
+			select {
+			case id := <-triggerCh:
+				assert.Equal(t, tc.name, id, "unexpected id")
+			case <-time.After(expectedWithin):
+				assert.Fail(t, "buffer did not complete within expected period", expectedWithin)
+			}
+
+			assert.True(t, bufferPeriods.Buffered(tc.name), "id should be cached as buffered")
+		})
+	}
+
+	t.Run("not configured", func(t *testing.T) {
+		triggerCh := make(chan string)
+		bufferPeriods := newTimers()
+		go bufferPeriods.Run(triggerCh)
+		defer bufferPeriods.Stop()
+
+		isBuffering := bufferPeriods.Buffer("dne")
+		assert.False(t, isBuffering, "buffer not configured, should not be buffering")
+
+		select {
+		case id := <-triggerCh:
+			assert.Fail(t, "unexpected ID when no buffer period was added", id)
+		case <-time.After(time.Millisecond):
+			// test passes
+		}
+	})
+}

--- a/buffer_period_test.go
+++ b/buffer_period_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestBufferPeriod(t *testing.T) {
+	t.Parallel() // test takes a few seconds
+
 	testCases := []struct {
 		name           string
 		min            time.Duration
@@ -41,7 +43,6 @@ func TestBufferPeriod(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			tc := testCase
 			t.Parallel()
-			expectedWithin := tc.min + time.Duration(tc.snoozeCount)*tc.snoozeAfter + time.Second
 
 			triggerCh := make(chan string)
 			bufferPeriods := newTimers()
@@ -57,12 +58,15 @@ func TestBufferPeriod(t *testing.T) {
 			// Simulate consecutive calls to resolver.Run(template)
 			go func() {
 				for i := int64(0); i < tc.snoozeCount; i++ {
-					<-time.After(tc.snoozeAfter * time.Second)
-					bufferPeriods.Buffer(tc.name)
+					<-time.After(tc.snoozeAfter)
+					active := bufferPeriods.Buffer(tc.name)
+					assert.True(t, active, "intentionally snoozing before buffer period completes")
 				}
 			}()
 
 			// Test signal is received within expected duration
+			expectedWithin := tc.min + time.Duration(tc.snoozeCount)*tc.snoozeAfter
+			expectedWithin += time.Second // add a second of leniency
 			select {
 			case id := <-triggerCh:
 				assert.Equal(t, tc.name, id, "unexpected id")
@@ -75,6 +79,8 @@ func TestBufferPeriod(t *testing.T) {
 	}
 
 	t.Run("not configured", func(t *testing.T) {
+		t.Parallel()
+
 		triggerCh := make(chan string)
 		bufferPeriods := newTimers()
 		go bufferPeriods.Run(triggerCh)
@@ -88,6 +94,36 @@ func TestBufferPeriod(t *testing.T) {
 			assert.Fail(t, "unexpected ID when no buffer period was added", id)
 		case <-time.After(time.Millisecond):
 			// test passes
+		}
+	})
+
+	t.Run("multiple", func(t *testing.T) {
+		t.Parallel()
+
+		triggerCh := make(chan string, 5)
+		bufferPeriods := newTimers()
+		go bufferPeriods.Run(triggerCh)
+		defer bufferPeriods.Stop()
+
+		first := time.Duration(2 * time.Second)
+		second := time.Duration(4 * time.Second)
+		bufferPeriods.Add(first, first*2, "first")
+		bufferPeriods.Add(second, second*2, "second")
+
+		bufferPeriods.Buffer("first")
+		bufferPeriods.Buffer("second")
+
+		completed := make(chan struct{})
+		go func() {
+			assert.Equal(t, "first", <-triggerCh)
+			assert.Equal(t, "second", <-triggerCh)
+			completed <- struct{}{}
+		}()
+
+		select {
+		case <-time.After(5 * time.Second):
+			assert.Fail(t, "expected both buffer periods to send a signal")
+		case <-completed:
 		}
 	})
 }

--- a/resolver.go
+++ b/resolver.go
@@ -32,6 +32,7 @@ type Watcherer interface {
 	Recaller
 	Add(dep.Dependency) bool
 	Changed(tmplID string) bool
+	Buffer(tmplID string) bool
 	Register(tmplID string, deps ...dep.Dependency)
 }
 
@@ -50,6 +51,10 @@ func (r *Resolver) Run(tmpl Templater, w Watcherer) (ResolveEvent, error) {
 	// if not, don't waste time re-rendering it.
 	if !w.Changed(tmpl.ID()) {
 		return ResolveEvent{}, nil
+	}
+
+	if w.Buffer(tmpl.ID()) {
+		return ResolveEvent{Complete: false}, nil
 	}
 
 	// Attempt to render the template, returning any missing dependencies and


### PR DESCRIPTION
Buffering periods reduce the number of times a template can render within a duration.

New methods to `Watcher`
```
// Configure buffer periods for templates by their ID
SetBufferPeriod(min, max time.Duration, tmplIDs ...string)

// Activate a buffer period for the template if configured
Buffer(tmplID string) bool
```

Clients only need to interface with `Watcher.SetBufferPeriod` and the watcher manages the buffer periods internally.