### PR TITLE
don't use consul client until leader is detected

### DIFF
--- a/internal/dependency/client_set.go
+++ b/internal/dependency/client_set.go
@@ -218,6 +218,9 @@ func (c *ClientSet) CreateVaultClient(i *CreateClientInput) error {
 func (c *ClientSet) Consul() *consulapi.Client {
 	c.RLock()
 	defer c.RUnlock()
+	if c == nil || c.consul == nil {
+		return nil
+	}
 	return c.consul.client
 }
 
@@ -225,6 +228,9 @@ func (c *ClientSet) Consul() *consulapi.Client {
 func (c *ClientSet) Vault() *vaultapi.Client {
 	c.RLock()
 	defer c.RUnlock()
+	if c == nil || c.vault == nil {
+		return nil
+	}
 	return c.vault.client
 }
 

--- a/looker.go
+++ b/looker.go
@@ -41,15 +41,13 @@ func NewClientSet() *ClientSet {
 }
 
 // AddConsul creates a Consul client and adds to the client set
-func (cs *ClientSet) AddConsul(i ConsulInput) *ClientSet {
-	cs.CreateConsulClient(i.toInternal())
-	return cs
+func (cs *ClientSet) AddConsul(i ConsulInput) error {
+	return cs.CreateConsulClient(i.toInternal())
 }
 
 // AddVault creates a Vault client and adds to the client set
-func (cs *ClientSet) AddVault(i VaultInput) *ClientSet {
-	cs.CreateVaultClient(i.toInternal())
-	return cs
+func (cs *ClientSet) AddVault(i VaultInput) error {
+	return cs.CreateVaultClient(i.toInternal())
 }
 
 // Stop closes all idle connections for any attached clients and clears


### PR DESCRIPTION
Consul cluster w/o a leader means potentially bad data. So don't set the
client as usable without confirming that a leader has been elected.

Fixes #9 

I wasn't able to come up with a good direct test of this, but it is indirectly tested fairly well.