### PR TITLE
Fix panic when stopping unused timers

### DIFF
--- a/buffer_period.go
+++ b/buffer_period.go
@@ -58,7 +58,7 @@ func (t *timers) Stop() {
 	defer t.mux.Unlock()
 
 	for id, timer := range t.timers {
-		timer.timer.Stop()
+		timer.stop()
 		delete(t.timers, id)
 	}
 }
@@ -111,6 +111,12 @@ func newTimer(ch chan string, min, max time.Duration, id string) *timer {
 		min: min,
 		max: max,
 		ch:  ch,
+	}
+}
+
+func (t *timer) stop() {
+	if t.timer != nil {
+		t.timer.Stop()
 	}
 }
 

--- a/buffer_period_test.go
+++ b/buffer_period_test.go
@@ -126,4 +126,15 @@ func TestBufferPeriod(t *testing.T) {
 		case <-completed:
 		}
 	})
+
+	t.Run("stop unused timers", func(t *testing.T) {
+		t.Parallel()
+
+		triggerCh := make(chan string, 5)
+		bufferPeriods := newTimers()
+		go bufferPeriods.Run(triggerCh)
+
+		bufferPeriods.Add(time.Second, 2*time.Second, "unused")
+		bufferPeriods.Stop()
+	})
 }


### PR DESCRIPTION
When buffer periods are added but not used, calling Stop() causes a panic.

```
--- FAIL: TestBufferPeriod (0.00s)
    --- FAIL: TestBufferPeriod/stop_unused_timers (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x14d06cd]

goroutine 13 [running]:
testing.tRunner.func1.1(0x1599380, 0x1ad4000)
	/usr/local/go/src/testing/testing.go:988 +0x30d
testing.tRunner.func1(0xc0001a7c20)
	/usr/local/go/src/testing/testing.go:991 +0x3f9
panic(0x1599380, 0x1ad4000)
	/usr/local/go/src/runtime/panic.go:969 +0x166
time.(*Timer).Stop(...)
	/usr/local/go/src/time/sleep.go:75
github.com/hashicorp/hcat.(*timers).Stop(0xc000114060)
	/Users/kngo/dev/hashicorp/hcat/buffer_period.go:61 +0x13d
github.com/hashicorp/hcat.TestBufferPeriod.func4(0xc0001a7c20)
	/Users/kngo/dev/hashicorp/hcat/buffer_period_test.go:138 +0x13d
testing.tRunner(0xc0001a7c20, 0x165f2d0)
	/usr/local/go/src/testing/testing.go:1039 +0xdc
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1090 +0x372
exit status 2
FAIL	github.com/hashicorp/hcat	1.388s
```