### PR TITLE
Export types returned by template function

### DIFF
--- a/dep/template_function_types.go
+++ b/dep/template_function_types.go
@@ -1,0 +1,126 @@
+package dep
+
+import (
+	"time"
+
+	"github.com/hashicorp/consul/api"
+)
+
+// Node is a node entry in Consul
+type Node struct {
+	ID              string
+	Node            string
+	Address         string
+	Datacenter      string
+	TaggedAddresses map[string]string
+	Meta            map[string]string
+}
+
+// CatalogNode is a wrapper around the node and its services.
+type CatalogNode struct {
+	Node     *Node
+	Services []*CatalogNodeService
+}
+
+// ServiceTags is a slice of tags assigned to a Service
+type ServiceTags []string
+
+// CatalogNodeService is a service on a single node.
+type CatalogNodeService struct {
+	ID                string
+	Service           string
+	Tags              ServiceTags
+	Meta              map[string]string
+	Port              int
+	Address           string
+	EnableTagOverride bool
+}
+
+// CatalogSnippet is a catalog entry in Consul.
+type CatalogSnippet struct {
+	Name string
+	Tags ServiceTags
+}
+
+// HealthService is a service entry in Consul.
+type HealthService struct {
+	Node                string
+	NodeID              string
+	NodeAddress         string
+	NodeDatacenter      string
+	NodeTaggedAddresses map[string]string
+	NodeMeta            map[string]string
+	ServiceMeta         map[string]string
+	Address             string
+	ID                  string
+	Name                string
+	Tags                ServiceTags
+	Checks              api.HealthChecks
+	Status              string
+	Port                int
+	Weights             api.AgentWeights
+	Namespace           string
+}
+
+// KeyPair is a simple Key-Value pair
+type KeyPair struct {
+	Path  string
+	Key   string
+	Value string
+
+	// Lesser-used, but still valuable keys from api.KV
+	CreateIndex uint64
+	ModifyIndex uint64
+	LockIndex   uint64
+	Flags       uint64
+	Session     string
+}
+
+// Secret is the structure returned for every secret within Vault.
+type Secret struct {
+	// The request ID that generated this response
+	RequestID string
+
+	LeaseID       string
+	LeaseDuration int
+	Renewable     bool
+
+	// Data is the actual contents of the secret. The format of the data
+	// is arbitrary and up to the secret backend.
+	Data map[string]interface{}
+
+	// Warnings contains any warnings related to the operation. These
+	// are not issues that caused the command to fail, but that the
+	// client should be aware of.
+	Warnings []string
+
+	// Auth, if non-nil, means that there was authentication information
+	// attached to this response.
+	Auth *SecretAuth
+
+	// WrapInfo, if non-nil, means that the initial response was wrapped in the
+	// cubbyhole of the given token (which has a TTL of the given number of
+	// seconds)
+	WrapInfo *SecretWrapInfo
+}
+
+// SecretAuth is the structure containing auth information if we have it.
+type SecretAuth struct {
+	ClientToken string
+	Accessor    string
+	Policies    []string
+	Metadata    map[string]string
+
+	LeaseDuration int
+	Renewable     bool
+}
+
+// SecretWrapInfo contains wrapping information if we have it. If what is
+// contained is an authentication token, the accessor for the token will be
+// available in WrappedAccessor.
+type SecretWrapInfo struct {
+	Token           string
+	TTL             int
+	CreationTime    time.Time
+	WrappedAccessor string
+}

--- a/internal/dependency/catalog_node.go
+++ b/internal/dependency/catalog_node.go
@@ -19,8 +19,8 @@ var (
 )
 
 func init() {
-	gob.Register([]*CatalogNode{})
-	gob.Register([]*CatalogNodeService{})
+	gob.Register([]*dep.CatalogNode{})
+	gob.Register([]*dep.CatalogNodeService{})
 }
 
 // CatalogNodeQuery represents a single node from the Consul catalog.
@@ -31,23 +31,6 @@ type CatalogNodeQuery struct {
 	dc   string
 	name string
 	opts QueryOptions
-}
-
-// CatalogNode is a wrapper around the node and its services.
-type CatalogNode struct {
-	Node     *Node
-	Services []*CatalogNodeService
-}
-
-// CatalogNodeService is a service on a single node.
-type CatalogNodeService struct {
-	ID                string
-	Service           string
-	Tags              ServiceTags
-	Meta              map[string]string
-	Port              int
-	Address           string
-	EnableTagOverride bool
 }
 
 // NewCatalogNodeQuery parses the given string into a dependency. If the name is
@@ -108,16 +91,16 @@ func (d *CatalogNodeQuery) Fetch(clients dep.Clients) (interface{}, *dep.Respons
 
 	if node == nil {
 		//log.Printf("[WARN] %s: no node exists with the name %q", d, name)
-		var node CatalogNode
+		var node dep.CatalogNode
 		return &node, rm, nil
 	}
 
-	services := make([]*CatalogNodeService, 0, len(node.Services))
+	services := make([]*dep.CatalogNodeService, 0, len(node.Services))
 	for _, v := range node.Services {
-		services = append(services, &CatalogNodeService{
+		services = append(services, &dep.CatalogNodeService{
 			ID:                v.ID,
 			Service:           v.Service,
-			Tags:              ServiceTags(deepCopyAndSortTags(v.Tags)),
+			Tags:              dep.ServiceTags(deepCopyAndSortTags(v.Tags)),
 			Meta:              v.Meta,
 			Port:              v.Port,
 			Address:           v.Address,
@@ -126,8 +109,8 @@ func (d *CatalogNodeQuery) Fetch(clients dep.Clients) (interface{}, *dep.Respons
 	}
 	sort.Stable(ByService(services))
 
-	detail := &CatalogNode{
-		Node: &Node{
+	detail := &dep.CatalogNode{
+		Node: &dep.Node{
 			ID:              node.Node.ID,
 			Node:            node.Node.Node,
 			Address:         node.Node.Address,
@@ -165,7 +148,7 @@ func (d *CatalogNodeQuery) Stop() {
 }
 
 // ByService is a sorter of node services by their service name and then ID.
-type ByService []*CatalogNodeService
+type ByService []*dep.CatalogNodeService
 
 func (s ByService) Len() int      { return len(s) }
 func (s ByService) Swap(i, j int) { s[i], s[j] = s[j], s[i] }

--- a/internal/dependency/catalog_node_test.go
+++ b/internal/dependency/catalog_node_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/hcat/dep"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -84,13 +85,13 @@ func TestCatalogNodeQuery_Fetch(t *testing.T) {
 	cases := []struct {
 		name string
 		i    string
-		exp  *CatalogNode
+		exp  *dep.CatalogNode
 	}{
 		{
 			"local",
 			"",
-			&CatalogNode{
-				Node: &Node{
+			&dep.CatalogNode{
+				Node: &dep.Node{
 					Node:       testConsul.Config.NodeName,
 					Address:    testConsul.Config.Bind,
 					Datacenter: "dc1",
@@ -102,25 +103,25 @@ func TestCatalogNodeQuery_Fetch(t *testing.T) {
 						"consul-network-segment": "",
 					},
 				},
-				Services: []*CatalogNodeService{
-					&CatalogNodeService{
+				Services: []*dep.CatalogNodeService{
+					&dep.CatalogNodeService{
 						ID:      "consul",
 						Service: "consul",
 						Port:    testConsul.Config.Ports.Server,
-						Tags:    ServiceTags([]string{}),
+						Tags:    dep.ServiceTags([]string{}),
 						Meta:    map[string]string{},
 					},
-					&CatalogNodeService{
+					&dep.CatalogNodeService{
 						ID:      "foo",
 						Service: "foo-sidecar-proxy",
-						Tags:    ServiceTags([]string{}),
+						Tags:    dep.ServiceTags([]string{}),
 						Meta:    map[string]string{},
 						Port:    21999,
 					},
-					&CatalogNodeService{
+					&dep.CatalogNodeService{
 						ID:      "service-meta",
 						Service: "service-meta",
-						Tags:    ServiceTags([]string{"tag1"}),
+						Tags:    dep.ServiceTags([]string{"tag1"}),
 						Meta: map[string]string{
 							"meta1": "value1",
 						},
@@ -131,7 +132,7 @@ func TestCatalogNodeQuery_Fetch(t *testing.T) {
 		{
 			"unknown",
 			"not_a_real_node",
-			&CatalogNode{},
+			&dep.CatalogNode{},
 		},
 	}
 
@@ -148,12 +149,12 @@ func TestCatalogNodeQuery_Fetch(t *testing.T) {
 			}
 
 			if act != nil {
-				if n := act.(*CatalogNode).Node; n != nil {
+				if n := act.(*dep.CatalogNode).Node; n != nil {
 					n.ID = ""
 					n.TaggedAddresses = filterAddresses(n.TaggedAddresses)
 				}
 				// delete any version data from ServiceMeta
-				services := act.(*CatalogNode).Services
+				services := act.(*dep.CatalogNode).Services
 				for i := range services {
 					services[i].Meta = filterVersionMeta(services[i].Meta)
 				}

--- a/internal/dependency/catalog_nodes.go
+++ b/internal/dependency/catalog_nodes.go
@@ -19,17 +19,7 @@ var (
 )
 
 func init() {
-	gob.Register([]*Node{})
-}
-
-// Node is a node entry in Consul
-type Node struct {
-	ID              string
-	Node            string
-	Address         string
-	Datacenter      string
-	TaggedAddresses map[string]string
-	Meta            map[string]string
+	gob.Register([]*dep.Node{})
 }
 
 // CatalogNodesQuery is the representation of all registered nodes in Consul.
@@ -82,9 +72,9 @@ func (d *CatalogNodesQuery) Fetch(clients dep.Clients) (interface{}, *dep.Respon
 
 	//log.Printf("[TRACE] %s: returned %d results", d, len(n))
 
-	nodes := make([]*Node, 0, len(n))
+	nodes := make([]*dep.Node, 0, len(n))
 	for _, node := range n {
-		nodes = append(nodes, &Node{
+		nodes = append(nodes, &dep.Node{
 			ID:              node.ID,
 			Node:            node.Node,
 			Address:         node.Address,
@@ -134,7 +124,7 @@ func (d *CatalogNodesQuery) Stop() {
 }
 
 // ByNode is a sortable list of nodes by name and then IP address.
-type ByNode []*Node
+type ByNode []*dep.Node
 
 func (s ByNode) Len() int      { return len(s) }
 func (s ByNode) Swap(i, j int) { s[i], s[j] = s[j], s[i] }

--- a/internal/dependency/catalog_nodes_test.go
+++ b/internal/dependency/catalog_nodes_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/hcat/dep"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -77,13 +78,13 @@ func TestCatalogNodesQuery_Fetch(t *testing.T) {
 	cases := []struct {
 		name string
 		i    string
-		exp  []*Node
+		exp  []*dep.Node
 	}{
 		{
 			"all",
 			"",
-			[]*Node{
-				&Node{
+			[]*dep.Node{
+				{
 					Node:       testConsul.Config.NodeName,
 					Address:    testConsul.Config.Bind,
 					Datacenter: "dc1",
@@ -112,7 +113,7 @@ func TestCatalogNodesQuery_Fetch(t *testing.T) {
 			}
 
 			if act != nil {
-				for _, n := range act.([]*Node) {
+				for _, n := range act.([]*dep.Node) {
 					n.ID = ""
 					n.TaggedAddresses = filterAddresses(n.TaggedAddresses)
 				}

--- a/internal/dependency/catalog_service.go
+++ b/internal/dependency/catalog_service.go
@@ -19,7 +19,7 @@ var (
 )
 
 func init() {
-	gob.Register([]*CatalogSnippet{})
+	gob.Register([]*dep.CatalogSnippet{})
 }
 
 // CatalogService is a catalog entry in Consul.
@@ -33,7 +33,7 @@ type CatalogService struct {
 	ServiceID       string
 	ServiceName     string
 	ServiceAddress  string
-	ServiceTags     ServiceTags
+	ServiceTags     dep.ServiceTags
 	ServiceMeta     map[string]string
 	ServicePort     int
 	Namespace       string
@@ -112,7 +112,7 @@ func (d *CatalogServiceQuery) Fetch(clients dep.Clients) (interface{}, *dep.Resp
 			ServiceID:       s.ServiceID,
 			ServiceName:     s.ServiceName,
 			ServiceAddress:  s.ServiceAddress,
-			ServiceTags:     ServiceTags(deepCopyAndSortTags(s.ServiceTags)),
+			ServiceTags:     dep.ServiceTags(deepCopyAndSortTags(s.ServiceTags)),
 			ServiceMeta:     s.ServiceMeta,
 			ServicePort:     s.ServicePort,
 			Namespace:       s.Namespace,

--- a/internal/dependency/catalog_service_test.go
+++ b/internal/dependency/catalog_service_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/hcat/dep"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -169,7 +170,7 @@ func TestCatalogServiceQuery_Fetch(t *testing.T) {
 					ServiceID:      "consul",
 					ServiceName:    "consul",
 					ServiceAddress: "",
-					ServiceTags:    ServiceTags([]string{}),
+					ServiceTags:    dep.ServiceTags([]string{}),
 					ServiceMeta:    map[string]string{},
 					ServicePort:    testConsul.Config.Ports.Server,
 				},
@@ -193,7 +194,7 @@ func TestCatalogServiceQuery_Fetch(t *testing.T) {
 					ServiceID:      "service-meta",
 					ServiceName:    "service-meta",
 					ServiceAddress: "",
-					ServiceTags:    ServiceTags([]string{"tag1"}),
+					ServiceTags:    dep.ServiceTags([]string{"tag1"}),
 					ServiceMeta:    map[string]string{"meta1": "value1"},
 				},
 			},

--- a/internal/dependency/catalog_services.go
+++ b/internal/dependency/catalog_services.go
@@ -19,13 +19,7 @@ var (
 )
 
 func init() {
-	gob.Register([]*CatalogSnippet{})
-}
-
-// CatalogSnippet is a catalog entry in Consul.
-type CatalogSnippet struct {
-	Name string
-	Tags ServiceTags
+	gob.Register([]*dep.CatalogSnippet{})
 }
 
 // CatalogServicesQuery is the representation of a requested catalog service
@@ -76,11 +70,11 @@ func (d *CatalogServicesQuery) Fetch(clients dep.Clients) (interface{}, *dep.Res
 
 	//log.Printf("[TRACE] %s: returned %d results", d, len(entries))
 
-	var catalogServices []*CatalogSnippet
+	var catalogServices []*dep.CatalogSnippet
 	for name, tags := range entries {
-		catalogServices = append(catalogServices, &CatalogSnippet{
+		catalogServices = append(catalogServices, &dep.CatalogSnippet{
 			Name: name,
-			Tags: ServiceTags(deepCopyAndSortTags(tags)),
+			Tags: dep.ServiceTags(deepCopyAndSortTags(tags)),
 		})
 	}
 
@@ -117,7 +111,7 @@ func (d *CatalogServicesQuery) SetOptions(opts QueryOptions) {
 }
 
 // ByName is a sortable slice of CatalogService structs.
-type ByName []*CatalogSnippet
+type ByName []*dep.CatalogSnippet
 
 func (s ByName) Len() int      { return len(s) }
 func (s ByName) Swap(i, j int) { s[i], s[j] = s[j], s[i] }

--- a/internal/dependency/catalog_services_test.go
+++ b/internal/dependency/catalog_services_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/hcat/dep"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -60,23 +61,23 @@ func TestCatalogServicesQuery_Fetch(t *testing.T) {
 	cases := []struct {
 		name string
 		i    string
-		exp  []*CatalogSnippet
+		exp  []*dep.CatalogSnippet
 	}{
 		{
 			"all",
 			"",
-			[]*CatalogSnippet{
-				&CatalogSnippet{
+			[]*dep.CatalogSnippet{
+				&dep.CatalogSnippet{
 					Name: "consul",
-					Tags: ServiceTags([]string{}),
+					Tags: dep.ServiceTags([]string{}),
 				},
-				&CatalogSnippet{
+				&dep.CatalogSnippet{
 					Name: "foo-sidecar-proxy",
-					Tags: ServiceTags([]string{}),
+					Tags: dep.ServiceTags([]string{}),
 				},
-				&CatalogSnippet{
+				&dep.CatalogSnippet{
 					Name: "service-meta",
-					Tags: ServiceTags([]string{"tag1"}),
+					Tags: dep.ServiceTags([]string{"tag1"}),
 				},
 			},
 		},

--- a/internal/dependency/dependency.go
+++ b/internal/dependency/dependency.go
@@ -159,9 +159,6 @@ func (q *QueryOptions) String() string {
 	return u.Encode()
 }
 
-// ServiceTags is a slice of tags assigned to a Service
-type ServiceTags []string
-
 // deepCopyAndSortTags deep copies the tags in the given string slice and then
 // sorts and returns the copied result.
 func deepCopyAndSortTags(tags []string) []string {

--- a/internal/dependency/health_service.go
+++ b/internal/dependency/health_service.go
@@ -8,7 +8,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/hcat/dep"
 	"github.com/pkg/errors"
 )
@@ -33,27 +32,7 @@ var (
 )
 
 func init() {
-	gob.Register([]*HealthService{})
-}
-
-// HealthService is a service entry in Consul.
-type HealthService struct {
-	Node                string
-	NodeID              string
-	NodeAddress         string
-	NodeDatacenter      string
-	NodeTaggedAddresses map[string]string
-	NodeMeta            map[string]string
-	ServiceMeta         map[string]string
-	Address             string
-	ID                  string
-	Name                string
-	Tags                ServiceTags
-	Checks              api.HealthChecks
-	Status              string
-	Port                int
-	Weights             api.AgentWeights
-	Namespace           string
+	gob.Register([]*dep.HealthService{})
 }
 
 // HealthServiceQuery is the representation of all a service query in Consul.
@@ -162,7 +141,7 @@ func (d *HealthServiceQuery) Fetch(clients dep.Clients) (interface{}, *dep.Respo
 
 	//log.Printf("[TRACE] %s: returned %d results", d, len(entries))
 
-	list := make([]*HealthService, 0, len(entries))
+	list := make([]*dep.HealthService, 0, len(entries))
 	for _, entry := range entries {
 		// Get the status of this service from its checks.
 		status := entry.Checks.AggregatedStatus()
@@ -180,7 +159,7 @@ func (d *HealthServiceQuery) Fetch(clients dep.Clients) (interface{}, *dep.Respo
 			address = entry.Node.Address
 		}
 
-		list = append(list, &HealthService{
+		list = append(list, &dep.HealthService{
 			Node:                entry.Node.Node,
 			NodeID:              entry.Node.ID,
 			NodeAddress:         entry.Node.Address,
@@ -191,7 +170,7 @@ func (d *HealthServiceQuery) Fetch(clients dep.Clients) (interface{}, *dep.Respo
 			Address:             address,
 			ID:                  entry.Service.ID,
 			Name:                entry.Service.Service,
-			Tags: ServiceTags(
+			Tags: dep.ServiceTags(
 				deepCopyAndSortTags(entry.Service.Tags)),
 			Status:    status,
 			Checks:    entry.Checks,
@@ -259,7 +238,7 @@ func acceptStatus(list []string, s string) bool {
 }
 
 // ByNodeThenID is a sortable slice of Service
-type ByNodeThenID []*HealthService
+type ByNodeThenID []*dep.HealthService
 
 // Len, Swap, and Less are used to implement the sort.Sort interface.
 func (s ByNodeThenID) Len() int      { return len(s) }

--- a/internal/dependency/health_service_test.go
+++ b/internal/dependency/health_service_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/hcat/dep"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -166,13 +167,13 @@ func TestHealthConnectServiceQuery_Fetch(t *testing.T) {
 	cases := []struct {
 		name string
 		in   string
-		exp  []*HealthService
+		exp  []*dep.HealthService
 	}{
 		{
 			"connect-service",
 			"foo",
-			[]*HealthService{
-				&HealthService{
+			[]*dep.HealthService{
+				&dep.HealthService{
 					Name:           "foo-sidecar-proxy",
 					ID:             "foo",
 					Port:           21999,
@@ -180,7 +181,7 @@ func TestHealthConnectServiceQuery_Fetch(t *testing.T) {
 					Address:        "127.0.0.1",
 					NodeAddress:    "127.0.0.1",
 					NodeDatacenter: "dc1",
-					Tags:           ServiceTags([]string{}),
+					Tags:           dep.ServiceTags([]string{}),
 					NodeMeta: map[string]string{
 						"consul-network-segment": ""},
 					Weights: api.AgentWeights{
@@ -205,8 +206,8 @@ func TestHealthConnectServiceQuery_Fetch(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			var act []*HealthService
-			if act = res.([]*HealthService); len(act) != 1 {
+			var act []*dep.HealthService
+			if act = res.([]*dep.HealthService); len(act) != 1 {
 				t.Fatal("Expected 1 result, got ", len(act))
 			}
 			// blank out fields we don't want to test
@@ -226,13 +227,13 @@ func TestHealthServiceQuery_Fetch(t *testing.T) {
 	cases := []struct {
 		name string
 		i    string
-		exp  []*HealthService
+		exp  []*dep.HealthService
 	}{
 		{
 			"consul",
 			"consul",
-			[]*HealthService{
-				&HealthService{
+			[]*dep.HealthService{
+				&dep.HealthService{
 					Node:           testConsul.Config.NodeName,
 					NodeAddress:    testConsul.Config.Bind,
 					NodeDatacenter: "dc1",
@@ -261,13 +262,13 @@ func TestHealthServiceQuery_Fetch(t *testing.T) {
 		{
 			"filters",
 			"consul|warning",
-			[]*HealthService{},
+			[]*dep.HealthService{},
 		},
 		{
 			"multifilter",
 			"consul|warning,passing",
-			[]*HealthService{
-				&HealthService{
+			[]*dep.HealthService{
+				&dep.HealthService{
 					Node:           testConsul.Config.NodeName,
 					NodeAddress:    testConsul.Config.Bind,
 					NodeDatacenter: "dc1",
@@ -296,8 +297,8 @@ func TestHealthServiceQuery_Fetch(t *testing.T) {
 		{
 			"service-meta",
 			"service-meta",
-			[]*HealthService{
-				&HealthService{
+			[]*dep.HealthService{
+				&dep.HealthService{
 					Node:           testConsul.Config.NodeName,
 					NodeAddress:    testConsul.Config.Bind,
 					NodeDatacenter: "dc1",
@@ -339,7 +340,7 @@ func TestHealthServiceQuery_Fetch(t *testing.T) {
 			}
 
 			if act != nil {
-				for _, v := range act.([]*HealthService) {
+				for _, v := range act.([]*dep.HealthService) {
 					v.NodeID = ""
 					v.Checks = nil
 					// delete any version data from ServiceMeta

--- a/internal/dependency/kv_list.go
+++ b/internal/dependency/kv_list.go
@@ -19,21 +19,7 @@ var (
 )
 
 func init() {
-	gob.Register([]*KeyPair{})
-}
-
-// KeyPair is a simple Key-Value pair
-type KeyPair struct {
-	Path  string
-	Key   string
-	Value string
-
-	// Lesser-used, but still valuable keys from api.KV
-	CreateIndex uint64
-	ModifyIndex uint64
-	LockIndex   uint64
-	Flags       uint64
-	Session     string
+	gob.Register([]*dep.KeyPair{})
 }
 
 // KVListQuery queries the KV store for a single key.
@@ -84,12 +70,12 @@ func (d *KVListQuery) Fetch(clients dep.Clients) (interface{}, *dep.ResponseMeta
 
 	//log.Printf("[TRACE] %s: returned %d pairs", d, len(list))
 
-	pairs := make([]*KeyPair, 0, len(list))
+	pairs := make([]*dep.KeyPair, 0, len(list))
 	for _, pair := range list {
 		key := strings.TrimPrefix(pair.Key, d.prefix)
 		key = strings.TrimLeft(key, "/")
 
-		pairs = append(pairs, &KeyPair{
+		pairs = append(pairs, &dep.KeyPair{
 			Path:        pair.Key,
 			Key:         key,
 			Value:       string(pair.Value),

--- a/internal/dependency/kv_list_test.go
+++ b/internal/dependency/kv_list_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/hcat/dep"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -154,12 +155,12 @@ func TestKVListQuery_Fetch(t *testing.T) {
 	cases := []struct {
 		name string
 		i    string
-		exp  []*KeyPair
+		exp  []*dep.KeyPair
 	}{
 		{
 			"exists",
 			"test-kv-list/prefix",
-			[]*KeyPair{
+			[]*dep.KeyPair{
 				{
 					Path:  "test-kv-list/prefix/foo",
 					Key:   "foo",
@@ -180,7 +181,7 @@ func TestKVListQuery_Fetch(t *testing.T) {
 		{
 			"trailing",
 			"test-kv-list/prefix/",
-			[]*KeyPair{
+			[]*dep.KeyPair{
 				{
 					Path:  "test-kv-list/prefix/foo",
 					Key:   "foo",
@@ -201,7 +202,7 @@ func TestKVListQuery_Fetch(t *testing.T) {
 		{
 			"no_exist",
 			"test-kv-list/not/a/real/prefix/like/ever",
-			[]*KeyPair{},
+			[]*dep.KeyPair{},
 		},
 	}
 
@@ -217,7 +218,7 @@ func TestKVListQuery_Fetch(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			for _, p := range act.([]*KeyPair) {
+			for _, p := range act.([]*dep.KeyPair) {
 				p.CreateIndex = 0
 				p.ModifyIndex = 0
 			}
@@ -295,7 +296,7 @@ func TestKVListQuery_Fetch(t *testing.T) {
 		case err := <-errCh:
 			t.Fatal(err)
 		case data := <-dataCh:
-			typed := data.([]*KeyPair)
+			typed := data.([]*dep.KeyPair)
 			if len(typed) == 0 {
 				t.Fatal("bad length")
 			}
@@ -304,7 +305,7 @@ func TestKVListQuery_Fetch(t *testing.T) {
 			act.CreateIndex = 0
 			act.ModifyIndex = 0
 
-			exp := &KeyPair{
+			exp := &dep.KeyPair{
 				Path:  "test-kv-list/prefix/foo",
 				Key:   "foo",
 				Value: "new-bar",

--- a/internal/dependency/vault_common_test.go
+++ b/internal/dependency/vault_common_test.go
@@ -5,6 +5,8 @@ import (
 	"strconv"
 	"testing"
 	"time"
+
+	"github.com/hashicorp/hcat/dep"
 )
 
 func init() {
@@ -12,13 +14,13 @@ func init() {
 }
 
 func TestVaultRenewDuration(t *testing.T) {
-	renewable := Secret{LeaseDuration: 100, Renewable: true}
+	renewable := dep.Secret{LeaseDuration: 100, Renewable: true}
 	renewableDur := leaseCheckWait(&renewable).Seconds()
 	if renewableDur < 16 || renewableDur >= 34 {
 		t.Fatalf("renewable duration is not within 1/6 to 1/3 of lease duration: %f", renewableDur)
 	}
 
-	nonRenewable := Secret{LeaseDuration: 100}
+	nonRenewable := dep.Secret{LeaseDuration: 100}
 	nonRenewableDur := leaseCheckWait(&nonRenewable).Seconds()
 	if nonRenewableDur < 85 || nonRenewableDur > 95 {
 		t.Fatalf("renewable duration is not within 85%% to 95%% of lease duration: %f", nonRenewableDur)
@@ -29,7 +31,7 @@ func TestVaultRenewDuration(t *testing.T) {
 		"ttl":             json.Number("30"),
 	}
 
-	nonRenewableRotated := Secret{LeaseDuration: 100, Data: data}
+	nonRenewableRotated := dep.Secret{LeaseDuration: 100, Data: data}
 	nonRenewableRotatedDur := leaseCheckWait(&nonRenewableRotated).Seconds()
 
 	// We expect a 1 second cushion
@@ -42,7 +44,7 @@ func TestVaultRenewDuration(t *testing.T) {
 		"ttl":             json.Number("5"),
 	}
 
-	nonRenewableRotated = Secret{LeaseDuration: 100, Data: data}
+	nonRenewableRotated = dep.Secret{LeaseDuration: 100, Data: data}
 	nonRenewableRotatedDur = leaseCheckWait(&nonRenewableRotated).Seconds()
 
 	// We expect a 1 second cushion
@@ -58,7 +60,7 @@ func TestVaultRenewDuration(t *testing.T) {
 		"certificate": "foobar",
 	}
 
-	nonRenewableCert := Secret{LeaseDuration: 100, Data: data}
+	nonRenewableCert := dep.Secret{LeaseDuration: 100, Data: data}
 	nonRenewableCertDur := leaseCheckWait(&nonRenewableCert).Seconds()
 	if nonRenewableCertDur < 85 || nonRenewableCertDur > 95 {
 		t.Fatalf("non renewable certificate duration is not within 85%% to 95%%: %f", nonRenewableCertDur)

--- a/internal/dependency/vault_read.go
+++ b/internal/dependency/vault_read.go
@@ -24,7 +24,7 @@ type VaultReadQuery struct {
 
 	rawPath     string
 	queryValues url.Values
-	secret      *Secret
+	secret      *dep.Secret
 	isKVv2      *bool
 	secretPath  string
 	opts        QueryOptions
@@ -106,7 +106,7 @@ func (d *VaultReadQuery) stopChan() chan struct{} {
 	return d.stopCh
 }
 
-func (d *VaultReadQuery) secrets() (*Secret, *api.Secret) {
+func (d *VaultReadQuery) secrets() (*dep.Secret, *api.Secret) {
 	return d.secret, d.vaultSecret
 }
 

--- a/internal/dependency/vault_read_test.go
+++ b/internal/dependency/vault_read_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/hcat/dep"
 	"github.com/hashicorp/vault/api"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
@@ -117,7 +118,7 @@ func TestVaultReadQuery_Fetch_KVv1(t *testing.T) {
 		{
 			"exists",
 			secretsPath + "/foo/bar",
-			&Secret{
+			&dep.Secret{
 				Data: map[string]interface{}{
 					"ttl": "100ms",
 					"zip": "zap",
@@ -146,10 +147,10 @@ func TestVaultReadQuery_Fetch_KVv1(t *testing.T) {
 			}
 
 			if act != nil {
-				act.(*Secret).RequestID = ""
-				act.(*Secret).LeaseID = ""
-				act.(*Secret).LeaseDuration = 0
-				act.(*Secret).Renewable = false
+				act.(*dep.Secret).RequestID = ""
+				act.(*dep.Secret).LeaseID = ""
+				act.(*dep.Secret).LeaseDuration = 0
+				act.(*dep.Secret).Renewable = false
 			}
 
 			assert.Equal(t, tc.exp, act)
@@ -307,7 +308,7 @@ func TestVaultReadQuery_Fetch_KVv2(t *testing.T) {
 		{
 			"exists",
 			secretsPath + "/foo/bar",
-			&Secret{
+			&dep.Secret{
 				Data: map[string]interface{}{
 					"data": map[string]interface{}{
 						"ttl": "100ms", // explicitly make this a short duration for testing
@@ -320,7 +321,7 @@ func TestVaultReadQuery_Fetch_KVv2(t *testing.T) {
 		{
 			"/data in path",
 			secretsPath + "/data/foo/bar",
-			&Secret{
+			&dep.Secret{
 				Data: map[string]interface{}{
 					"data": map[string]interface{}{
 						"ttl": "100ms", // explicitly make this a short duration for testing
@@ -333,7 +334,7 @@ func TestVaultReadQuery_Fetch_KVv2(t *testing.T) {
 		{
 			"version=1",
 			secretsPath + "/foo/bar?version=1",
-			&Secret{
+			&dep.Secret{
 				Data: map[string]interface{}{
 					"data": map[string]interface{}{
 						"ttl": "100ms", // explicitly make this a short duration for testing
@@ -346,7 +347,7 @@ func TestVaultReadQuery_Fetch_KVv2(t *testing.T) {
 		{
 			"/data in path and in prefix",
 			secretsPath + "/data/datafoo/bar",
-			&Secret{
+			&dep.Secret{
 				Data: map[string]interface{}{
 					"data": map[string]interface{}{
 						"ttl": "100ms",
@@ -359,7 +360,7 @@ func TestVaultReadQuery_Fetch_KVv2(t *testing.T) {
 		{
 			"without /data/ in path, but contains data prefix",
 			secretsPath + "/datafoo/bar",
-			&Secret{
+			&dep.Secret{
 				Data: map[string]interface{}{
 					"data": map[string]interface{}{
 						"ttl": "100ms",
@@ -390,11 +391,11 @@ func TestVaultReadQuery_Fetch_KVv2(t *testing.T) {
 			}
 
 			if act != nil {
-				act.(*Secret).RequestID = ""
-				act.(*Secret).LeaseID = ""
-				act.(*Secret).LeaseDuration = 0
-				act.(*Secret).Renewable = false
-				tc.exp.(*Secret).Data["metadata"] = act.(*Secret).Data["metadata"]
+				act.(*dep.Secret).RequestID = ""
+				act.(*dep.Secret).LeaseID = ""
+				act.(*dep.Secret).LeaseDuration = 0
+				act.(*dep.Secret).Renewable = false
+				tc.exp.(*dep.Secret).Data["metadata"] = act.(*dep.Secret).Data["metadata"]
 			}
 
 			assert.Equal(t, tc.exp, act)
@@ -559,7 +560,7 @@ func TestVaultReadQuery_Fetch_PKI_Anonymous(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sec, ok := act.(*Secret)
+	sec, ok := act.(*dep.Secret)
 	if !ok {
 		t.Fatalf("expected secret but found %v", reflect.TypeOf(act))
 	}
@@ -622,7 +623,7 @@ func TestVaultReadQuery_Fetch_NonSecrets(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sec, ok := act.(*Secret)
+	sec, ok := act.(*dep.Secret)
 	if !ok {
 		t.Fatalf("expected secret but found %v", reflect.TypeOf(act))
 	}

--- a/internal/dependency/vault_token.go
+++ b/internal/dependency/vault_token.go
@@ -15,7 +15,7 @@ var (
 type VaultTokenQuery struct {
 	isVault
 	stopCh      chan struct{}
-	secret      *Secret
+	secret      *dep.Secret
 	vaultSecret *api.Secret
 }
 
@@ -57,7 +57,7 @@ func (d *VaultTokenQuery) stopChan() chan struct{} {
 	return d.stopCh
 }
 
-func (d *VaultTokenQuery) secrets() (*Secret, *api.Secret) {
+func (d *VaultTokenQuery) secrets() (*dep.Secret, *api.Secret) {
 	return d.secret, d.vaultSecret
 }
 

--- a/internal/dependency/vault_token_test.go
+++ b/internal/dependency/vault_token_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/hcat/dep"
 	"github.com/hashicorp/vault/api"
 	"github.com/stretchr/testify/assert"
 )
@@ -19,8 +20,8 @@ func TestNewVaultTokenQuery(t *testing.T) {
 		{
 			"default",
 			&VaultTokenQuery{
-				secret: &Secret{
-					Auth: &SecretAuth{
+				secret: &dep.Secret{
+					Auth: &dep.SecretAuth{
 						ClientToken:   "my-token",
 						Renewable:     true,
 						LeaseDuration: 1,

--- a/internal/dependency/vault_write.go
+++ b/internal/dependency/vault_write.go
@@ -27,7 +27,7 @@ type VaultWriteQuery struct {
 	path     string
 	data     map[string]interface{}
 	dataHash string
-	secret   *Secret
+	secret   *dep.Secret
 	opts     QueryOptions
 
 	// vaultSecret is the actual Vault secret which we are renewing
@@ -103,7 +103,7 @@ func (d *VaultWriteQuery) stopChan() chan struct{} {
 	return d.stopCh
 }
 
-func (d *VaultWriteQuery) secrets() (*Secret, *api.Secret) {
+func (d *VaultWriteQuery) secrets() (*dep.Secret, *api.Secret) {
 	return d.secret, d.vaultSecret
 }
 

--- a/internal/dependency/vault_write_test.go
+++ b/internal/dependency/vault_write_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/hcat/dep"
 	"github.com/hashicorp/vault/api"
 	"github.com/stretchr/testify/assert"
 )
@@ -175,7 +176,7 @@ func TestVaultWriteQuery_Fetch(t *testing.T) {
 			map[string]interface{}{
 				"plaintext": b64("test"),
 			},
-			&Secret{
+			&dep.Secret{
 				Data: map[string]interface{}{
 					"ciphertext": "",
 				},
@@ -204,12 +205,12 @@ func TestVaultWriteQuery_Fetch(t *testing.T) {
 			}
 
 			if act != nil {
-				act.(*Secret).RequestID = ""
-				act.(*Secret).LeaseID = ""
-				act.(*Secret).LeaseDuration = 0
-				act.(*Secret).Renewable = false
-				if act.(*Secret).Data["ciphertext"] != "" {
-					act.(*Secret).Data["ciphertext"] = ""
+				act.(*dep.Secret).RequestID = ""
+				act.(*dep.Secret).LeaseID = ""
+				act.(*dep.Secret).LeaseDuration = 0
+				act.(*dep.Secret).Renewable = false
+				if act.(*dep.Secret).Data["ciphertext"] != "" {
+					act.(*dep.Secret).Data["ciphertext"] = ""
 				}
 			}
 

--- a/store_test.go
+++ b/store_test.go
@@ -4,7 +4,8 @@ import (
 	"reflect"
 	"testing"
 
-	dep "github.com/hashicorp/hcat/internal/dependency"
+	"github.com/hashicorp/hcat/dep"
+	idep "github.com/hashicorp/hcat/internal/dependency"
 )
 
 func TestNewStore(t *testing.T) {
@@ -24,7 +25,7 @@ func TestRecall(t *testing.T) {
 	t.Parallel()
 	st := NewStore()
 
-	d, err := dep.NewCatalogNodesQuery("")
+	d, err := idep.NewCatalogNodesQuery("")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -54,7 +55,7 @@ func TestForceSet(t *testing.T) {
 	t.Parallel()
 	st := NewStore()
 
-	d, err := dep.NewCatalogNodesQuery("")
+	d, err := idep.NewCatalogNodesQuery("")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -83,7 +84,7 @@ func TestForget(t *testing.T) {
 	t.Parallel()
 	st := NewStore()
 
-	d, err := dep.NewCatalogNodesQuery("")
+	d, err := idep.NewCatalogNodesQuery("")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -108,7 +109,7 @@ func TestReset(t *testing.T) {
 	t.Parallel()
 	st := NewStore()
 
-	d, err := dep.NewCatalogNodesQuery("")
+	d, err := idep.NewCatalogNodesQuery("")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/template_funcs.go
+++ b/template_funcs.go
@@ -219,15 +219,15 @@ func keyWithDefaultFunc(r Recaller, used, missing *DepSet) func(string, string) 
 	}
 }
 
-func safeLsFunc(r Recaller, used, missing *DepSet) func(string) ([]*idep.KeyPair, error) {
+func safeLsFunc(r Recaller, used, missing *DepSet) func(string) ([]*dep.KeyPair, error) {
 	// call lsFunc but explicitly mark that empty data set returned on monitored KV prefix is NOT safe
 	return lsFunc(r, used, missing, false)
 }
 
 // lsFunc returns or accumulates keyPrefix dependencies.
-func lsFunc(r Recaller, used, missing *DepSet, emptyIsSafe bool) func(string) ([]*idep.KeyPair, error) {
-	return func(s string) ([]*idep.KeyPair, error) {
-		result := []*idep.KeyPair{}
+func lsFunc(r Recaller, used, missing *DepSet, emptyIsSafe bool) func(string) ([]*dep.KeyPair, error) {
+	return func(s string) ([]*dep.KeyPair, error) {
+		result := []*dep.KeyPair{}
 
 		if len(s) == 0 {
 			return result, nil
@@ -242,7 +242,7 @@ func lsFunc(r Recaller, used, missing *DepSet, emptyIsSafe bool) func(string) ([
 
 		// Only return non-empty top-level keys
 		if value, ok := r.Recall(d.String()); ok {
-			for _, pair := range value.([]*idep.KeyPair) {
+			for _, pair := range value.([]*dep.KeyPair) {
 				if pair.Key != "" && !strings.Contains(pair.Key, "/") {
 					result = append(result, pair)
 				}
@@ -273,8 +273,8 @@ func lsFunc(r Recaller, used, missing *DepSet, emptyIsSafe bool) func(string) ([
 }
 
 // nodeFunc returns or accumulates catalog node dependency.
-func nodeFunc(r Recaller, used, missing *DepSet) func(...string) (*idep.CatalogNode, error) {
-	return func(s ...string) (*idep.CatalogNode, error) {
+func nodeFunc(r Recaller, used, missing *DepSet) func(...string) (*dep.CatalogNode, error) {
+	return func(s ...string) (*dep.CatalogNode, error) {
 
 		d, err := idep.NewCatalogNodeQuery(strings.Join(s, ""))
 		if err != nil {
@@ -284,7 +284,7 @@ func nodeFunc(r Recaller, used, missing *DepSet) func(...string) (*idep.CatalogN
 		used.Add(d)
 
 		if value, ok := r.Recall(d.String()); ok {
-			return value.(*idep.CatalogNode), nil
+			return value.(*dep.CatalogNode), nil
 		}
 
 		missing.Add(d)
@@ -294,9 +294,9 @@ func nodeFunc(r Recaller, used, missing *DepSet) func(...string) (*idep.CatalogN
 }
 
 // nodesFunc returns or accumulates catalog node dependencies.
-func nodesFunc(r Recaller, used, missing *DepSet) func(...string) ([]*idep.Node, error) {
-	return func(s ...string) ([]*idep.Node, error) {
-		result := []*idep.Node{}
+func nodesFunc(r Recaller, used, missing *DepSet) func(...string) ([]*dep.Node, error) {
+	return func(s ...string) ([]*dep.Node, error) {
+		result := []*dep.Node{}
 
 		d, err := idep.NewCatalogNodesQuery(strings.Join(s, ""))
 		if err != nil {
@@ -306,7 +306,7 @@ func nodesFunc(r Recaller, used, missing *DepSet) func(...string) ([]*idep.Node,
 		used.Add(d)
 
 		if value, ok := r.Recall(d.String()); ok {
-			return value.([]*idep.Node), nil
+			return value.([]*dep.Node), nil
 		}
 
 		missing.Add(d)
@@ -316,9 +316,9 @@ func nodesFunc(r Recaller, used, missing *DepSet) func(...string) ([]*idep.Node,
 }
 
 // secretFunc returns or accumulates secret dependencies from Vault.
-func secretFunc(r Recaller, used, missing *DepSet) func(...string) (*idep.Secret, error) {
-	return func(s ...string) (*idep.Secret, error) {
-		var result *idep.Secret
+func secretFunc(r Recaller, used, missing *DepSet) func(...string) (*dep.Secret, error) {
+	return func(s ...string) (*dep.Secret, error) {
+		var result *dep.Secret
 
 		if len(s) == 0 {
 			return result, nil
@@ -353,7 +353,7 @@ func secretFunc(r Recaller, used, missing *DepSet) func(...string) (*idep.Secret
 		used.Add(d)
 
 		if value, ok := r.Recall(d.String()); ok {
-			result = value.(*idep.Secret)
+			result = value.(*dep.Secret)
 			return result, nil
 		}
 
@@ -391,7 +391,7 @@ func secretsFunc(r Recaller, used, missing *DepSet) func(string) ([]string, erro
 }
 
 // byMeta returns Services grouped by one or many ServiceMeta fields.
-func byMeta(meta string, services []*idep.HealthService) (groups map[string][]*idep.HealthService, err error) {
+func byMeta(meta string, services []*dep.HealthService) (groups map[string][]*dep.HealthService, err error) {
 	re := regexp.MustCompile("[^a-zA-Z0-9_-]")
 	normalize := func(x string) string {
 		return re.ReplaceAllString(x, "_")
@@ -409,7 +409,7 @@ func byMeta(meta string, services []*idep.HealthService) (groups map[string][]*i
 
 	metas := strings.Split(meta, ",")
 
-	groups = make(map[string][]*idep.HealthService)
+	groups = make(map[string][]*dep.HealthService)
 
 	for _, s := range services {
 		sm := s.ServiceMeta
@@ -434,9 +434,9 @@ func byMeta(meta string, services []*idep.HealthService) (groups map[string][]*i
 }
 
 // serviceFunc returns or accumulates health service dependencies.
-func serviceFunc(r Recaller, used, missing *DepSet) func(...string) ([]*idep.HealthService, error) {
-	return func(s ...string) ([]*idep.HealthService, error) {
-		result := []*idep.HealthService{}
+func serviceFunc(r Recaller, used, missing *DepSet) func(...string) ([]*dep.HealthService, error) {
+	return func(s ...string) ([]*dep.HealthService, error) {
+		result := []*dep.HealthService{}
 
 		if len(s) == 0 || s[0] == "" {
 			return result, nil
@@ -450,7 +450,7 @@ func serviceFunc(r Recaller, used, missing *DepSet) func(...string) ([]*idep.Hea
 		used.Add(d)
 
 		if value, ok := r.Recall(d.String()); ok {
-			return value.([]*idep.HealthService), nil
+			return value.([]*dep.HealthService), nil
 		}
 
 		missing.Add(d)
@@ -460,9 +460,9 @@ func serviceFunc(r Recaller, used, missing *DepSet) func(...string) ([]*idep.Hea
 }
 
 // servicesFunc returns or accumulates catalog services dependencies.
-func servicesFunc(r Recaller, used, missing *DepSet) func(...string) ([]*idep.CatalogSnippet, error) {
-	return func(s ...string) ([]*idep.CatalogSnippet, error) {
-		result := []*idep.CatalogSnippet{}
+func servicesFunc(r Recaller, used, missing *DepSet) func(...string) ([]*dep.CatalogSnippet, error) {
+	return func(s ...string) ([]*dep.CatalogSnippet, error) {
+		result := []*dep.CatalogSnippet{}
 
 		d, err := idep.NewCatalogServicesQuery(strings.Join(s, ""))
 		if err != nil {
@@ -472,7 +472,7 @@ func servicesFunc(r Recaller, used, missing *DepSet) func(...string) ([]*idep.Ca
 		used.Add(d)
 
 		if value, ok := r.Recall(d.String()); ok {
-			return value.([]*idep.CatalogSnippet), nil
+			return value.([]*dep.CatalogSnippet), nil
 		}
 
 		missing.Add(d)
@@ -482,9 +482,9 @@ func servicesFunc(r Recaller, used, missing *DepSet) func(...string) ([]*idep.Ca
 }
 
 // connectFunc returns or accumulates health connect dependencies.
-func connectFunc(r Recaller, used, missing *DepSet) func(...string) ([]*idep.HealthService, error) {
-	return func(s ...string) ([]*idep.HealthService, error) {
-		result := []*idep.HealthService{}
+func connectFunc(r Recaller, used, missing *DepSet) func(...string) ([]*dep.HealthService, error) {
+	return func(s ...string) ([]*dep.HealthService, error) {
+		result := []*dep.HealthService{}
 
 		if len(s) == 0 || s[0] == "" {
 			return result, nil
@@ -498,7 +498,7 @@ func connectFunc(r Recaller, used, missing *DepSet) func(...string) ([]*idep.Hea
 		used.Add(d)
 
 		if value, ok := r.Recall(d.String()); ok {
-			return value.([]*idep.HealthService), nil
+			return value.([]*dep.HealthService), nil
 		}
 
 		missing.Add(d)
@@ -537,16 +537,16 @@ func connectLeafFunc(r Recaller, used, missing *DepSet,
 	}
 }
 
-func safeTreeFunc(r Recaller, used, missing *DepSet) func(string) ([]*idep.KeyPair, error) {
+func safeTreeFunc(r Recaller, used, missing *DepSet) func(string) ([]*dep.KeyPair, error) {
 	// call treeFunc but explicitly mark that empty data set returned on
 	// monitored KV prefix is NOT safe
 	return treeFunc(r, used, missing, false)
 }
 
 // treeFunc returns or accumulates keyPrefix dependencies.
-func treeFunc(r Recaller, used, missing *DepSet, emptyIsSafe bool) func(string) ([]*idep.KeyPair, error) {
-	return func(s string) ([]*idep.KeyPair, error) {
-		result := []*idep.KeyPair{}
+func treeFunc(r Recaller, used, missing *DepSet, emptyIsSafe bool) func(string) ([]*dep.KeyPair, error) {
+	return func(s string) ([]*dep.KeyPair, error) {
+		result := []*dep.KeyPair{}
 
 		if len(s) == 0 {
 			return result, nil
@@ -561,7 +561,7 @@ func treeFunc(r Recaller, used, missing *DepSet, emptyIsSafe bool) func(string) 
 
 		// Only return non-empty top-level keys
 		if value, ok := r.Recall(d.String()); ok {
-			for _, pair := range value.([]*idep.KeyPair) {
+			for _, pair := range value.([]*dep.KeyPair) {
 				parts := strings.Split(pair.Key, "/")
 				if parts[len(parts)-1] != "" {
 					result = append(result, pair)
@@ -637,8 +637,8 @@ func base64URLEncode(s string) (string, error) {
 //
 // Note that the top-most key is stripped from the Key value. Keys that have no
 // prefix after stripping are removed from the list.
-func byKey(pairs []*idep.KeyPair) (map[string]map[string]*idep.KeyPair, error) {
-	m := make(map[string]map[string]*idep.KeyPair)
+func byKey(pairs []*dep.KeyPair) (map[string]map[string]*dep.KeyPair, error) {
+	m := make(map[string]map[string]*dep.KeyPair)
 	for _, pair := range pairs {
 		parts := strings.Split(pair.Key, "/")
 		top := parts[0]
@@ -650,7 +650,7 @@ func byKey(pairs []*idep.KeyPair) (map[string]map[string]*idep.KeyPair, error) {
 		}
 
 		if _, ok := m[top]; !ok {
-			m[top] = make(map[string]*idep.KeyPair)
+			m[top] = make(map[string]*dep.KeyPair)
 		}
 
 		newPair := *pair
@@ -671,7 +671,7 @@ func byTag(in interface{}) (map[string][]interface{}, error) {
 
 	switch typed := in.(type) {
 	case nil:
-	case []*idep.CatalogSnippet:
+	case []*dep.CatalogSnippet:
 		for _, s := range typed {
 			for _, t := range s.Tags {
 				m[t] = append(m[t], s)
@@ -683,7 +683,7 @@ func byTag(in interface{}) (map[string][]interface{}, error) {
 				m[t] = append(m[t], s)
 			}
 		}
-	case []*idep.HealthService:
+	case []*dep.HealthService:
 		for _, s := range typed {
 			for _, t := range s.Tags {
 				m[t] = append(m[t], s)
@@ -726,7 +726,7 @@ func containsSomeFunc(retTrue, invert bool) func([]interface{}, interface{}) (bo
 }
 
 // explode is used to expand a list of keypairs into a deeply-nested hash.
-func explode(pairs []*idep.KeyPair) (map[string]interface{}, error) {
+func explode(pairs []*dep.KeyPair) (map[string]interface{}, error) {
 	m := make(map[string]interface{})
 	for _, pair := range pairs {
 		if err := explodeHelper(m, pair.Key, pair.Value, pair.Key); err != nil {

--- a/template_funcs_test.go
+++ b/template_funcs_test.go
@@ -7,7 +7,7 @@ import (
 	"runtime"
 	"testing"
 
-	dep "github.com/hashicorp/hcat/internal/dependency"
+	"github.com/hashicorp/hcat/dep"
 )
 
 // NOTE: the template functions are all tested in ./template_test.go and

--- a/template_test.go
+++ b/template_test.go
@@ -11,7 +11,8 @@ import (
 	"time"
 
 	"github.com/hashicorp/consul/api"
-	dep "github.com/hashicorp/hcat/internal/dependency"
+	"github.com/hashicorp/hcat/dep"
+	idep "github.com/hashicorp/hcat/internal/dependency"
 )
 
 func TestNewTemplate(t *testing.T) {
@@ -211,7 +212,7 @@ func TestTemplate_Execute(t *testing.T) {
 			},
 			func() *Store {
 				st := NewStore()
-				d, err := dep.NewCatalogDatacentersQuery(false)
+				d, err := idep.NewCatalogDatacentersQuery(false)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -228,7 +229,7 @@ func TestTemplate_Execute(t *testing.T) {
 			},
 			func() *Store {
 				st := NewStore()
-				d, err := dep.NewCatalogDatacentersQuery(true)
+				d, err := idep.NewCatalogDatacentersQuery(true)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -245,7 +246,7 @@ func TestTemplate_Execute(t *testing.T) {
 			},
 			func() *Store {
 				st := NewStore()
-				d, err := dep.NewFileQuery("/path/to/file")
+				d, err := idep.NewFileQuery("/path/to/file")
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -262,7 +263,7 @@ func TestTemplate_Execute(t *testing.T) {
 			},
 			func() *Store {
 				st := NewStore()
-				d, err := dep.NewKVGetQuery("key")
+				d, err := idep.NewKVGetQuery("key")
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -279,7 +280,7 @@ func TestTemplate_Execute(t *testing.T) {
 			},
 			func() *Store {
 				st := NewStore()
-				d, err := dep.NewKVGetQuery("key")
+				d, err := idep.NewKVGetQuery("key")
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -296,7 +297,7 @@ func TestTemplate_Execute(t *testing.T) {
 			},
 			func() *Store {
 				st := NewStore()
-				d, err := dep.NewKVGetQuery("key")
+				d, err := idep.NewKVGetQuery("key")
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -313,7 +314,7 @@ func TestTemplate_Execute(t *testing.T) {
 			},
 			func() *Store {
 				st := NewStore()
-				d, err := dep.NewKVListQuery("list")
+				d, err := idep.NewKVListQuery("list")
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -334,7 +335,7 @@ func TestTemplate_Execute(t *testing.T) {
 			},
 			func() *Store {
 				st := NewStore()
-				d, err := dep.NewCatalogNodeQuery("")
+				d, err := idep.NewCatalogNodeQuery("")
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -358,7 +359,7 @@ func TestTemplate_Execute(t *testing.T) {
 			},
 			func() *Store {
 				st := NewStore()
-				d, err := dep.NewCatalogNodesQuery("")
+				d, err := idep.NewCatalogNodesQuery("")
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -378,7 +379,7 @@ func TestTemplate_Execute(t *testing.T) {
 			},
 			func() *Store {
 				st := NewStore()
-				d, err := dep.NewVaultReadQuery("secret/foo")
+				d, err := idep.NewVaultReadQuery("secret/foo")
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -400,14 +401,14 @@ func TestTemplate_Execute(t *testing.T) {
 			},
 			func() *Store {
 				st := NewStore()
-				d, err := dep.NewVaultReadQuery("secret/foo")
+				d, err := idep.NewVaultReadQuery("secret/foo")
 				if err != nil {
 					t.Fatal(err)
 				}
 				st.Save(d.String(), &dep.Secret{
 					Data: map[string]interface{}{"zip": "zap"},
 				})
-				d1, err := dep.NewVaultReadQuery("secret/foo?version=1")
+				d1, err := idep.NewVaultReadQuery("secret/foo?version=1")
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -448,7 +449,7 @@ func TestTemplate_Execute(t *testing.T) {
 			},
 			func() *Store {
 				st := NewStore()
-				d, err := dep.NewVaultWriteQuery("transit/encrypt/foo", map[string]interface{}{
+				d, err := idep.NewVaultWriteQuery("transit/encrypt/foo", map[string]interface{}{
 					"plaintext": "a",
 				})
 				if err != nil {
@@ -505,7 +506,7 @@ func TestTemplate_Execute(t *testing.T) {
 			},
 			func() *Store {
 				st := NewStore()
-				d, err := dep.NewVaultListQuery("secret/")
+				d, err := idep.NewVaultListQuery("secret/")
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -555,7 +556,7 @@ func TestTemplate_Execute(t *testing.T) {
 			},
 			func() *Store {
 				st := NewStore()
-				d, err := dep.NewHealthServiceQuery("webapp")
+				d, err := idep.NewHealthServiceQuery("webapp")
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -581,7 +582,7 @@ func TestTemplate_Execute(t *testing.T) {
 			},
 			func() *Store {
 				st := NewStore()
-				d, err := dep.NewHealthServiceQuery("webapp|passing,any")
+				d, err := idep.NewHealthServiceQuery("webapp|passing,any")
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -607,7 +608,7 @@ func TestTemplate_Execute(t *testing.T) {
 			},
 			func() *Store {
 				st := NewStore()
-				d, err := dep.NewCatalogServicesQuery("")
+				d, err := idep.NewCatalogServicesQuery("")
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -631,7 +632,7 @@ func TestTemplate_Execute(t *testing.T) {
 			},
 			func() *Store {
 				st := NewStore()
-				d, err := dep.NewKVListQuery("key")
+				d, err := idep.NewKVListQuery("key")
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -702,7 +703,7 @@ func TestTemplate_Execute(t *testing.T) {
 			},
 			func() *Store {
 				st := NewStore()
-				d, err := dep.NewKVListQuery("list")
+				d, err := idep.NewKVListQuery("list")
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -723,7 +724,7 @@ func TestTemplate_Execute(t *testing.T) {
 			},
 			func() *Store {
 				st := NewStore()
-				d, err := dep.NewHealthServiceQuery("webapp")
+				d, err := idep.NewHealthServiceQuery("webapp")
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -749,7 +750,7 @@ func TestTemplate_Execute(t *testing.T) {
 			},
 			func() *Store {
 				st := NewStore()
-				d, err := dep.NewHealthServiceQuery("webapp")
+				d, err := idep.NewHealthServiceQuery("webapp")
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -775,7 +776,7 @@ func TestTemplate_Execute(t *testing.T) {
 			},
 			func() *Store {
 				st := NewStore()
-				d, err := dep.NewHealthServiceQuery("webapp")
+				d, err := idep.NewHealthServiceQuery("webapp")
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -801,7 +802,7 @@ func TestTemplate_Execute(t *testing.T) {
 			},
 			func() *Store {
 				st := NewStore()
-				d, err := dep.NewHealthServiceQuery("webapp")
+				d, err := idep.NewHealthServiceQuery("webapp")
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -827,7 +828,7 @@ func TestTemplate_Execute(t *testing.T) {
 			},
 			func() *Store {
 				st := NewStore()
-				d, err := dep.NewHealthServiceQuery("webapp")
+				d, err := idep.NewHealthServiceQuery("webapp")
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -853,7 +854,7 @@ func TestTemplate_Execute(t *testing.T) {
 			},
 			func() *Store {
 				st := NewStore()
-				d, err := dep.NewHealthServiceQuery("webapp")
+				d, err := idep.NewHealthServiceQuery("webapp")
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -879,7 +880,7 @@ func TestTemplate_Execute(t *testing.T) {
 			},
 			func() *Store {
 				st := NewStore()
-				d, err := dep.NewHealthServiceQuery("webapp")
+				d, err := idep.NewHealthServiceQuery("webapp")
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -905,7 +906,7 @@ func TestTemplate_Execute(t *testing.T) {
 			},
 			func() *Store {
 				st := NewStore()
-				d, err := dep.NewHealthServiceQuery("webapp")
+				d, err := idep.NewHealthServiceQuery("webapp")
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -931,7 +932,7 @@ func TestTemplate_Execute(t *testing.T) {
 			},
 			func() *Store {
 				st := NewStore()
-				d, err := dep.NewHealthServiceQuery("webapp")
+				d, err := idep.NewHealthServiceQuery("webapp")
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -957,7 +958,7 @@ func TestTemplate_Execute(t *testing.T) {
 			},
 			func() *Store {
 				st := NewStore()
-				d, err := dep.NewHealthServiceQuery("webapp")
+				d, err := idep.NewHealthServiceQuery("webapp")
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -993,7 +994,7 @@ func TestTemplate_Execute(t *testing.T) {
 			},
 			func() *Store {
 				st := NewStore()
-				d, err := dep.NewKVGetQuery("foo")
+				d, err := idep.NewKVGetQuery("foo")
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -1010,7 +1011,7 @@ func TestTemplate_Execute(t *testing.T) {
 			},
 			func() *Store {
 				st := NewStore()
-				d, err := dep.NewKVGetQuery("foo")
+				d, err := idep.NewKVGetQuery("foo")
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -1027,7 +1028,7 @@ func TestTemplate_Execute(t *testing.T) {
 			},
 			func() *Store {
 				st := NewStore()
-				d, err := dep.NewKVListQuery("list")
+				d, err := idep.NewKVListQuery("list")
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -1057,7 +1058,7 @@ func TestTemplate_Execute(t *testing.T) {
 			},
 			func() *Store {
 				st := NewStore()
-				d, err := dep.NewHealthServiceQuery("webapp")
+				d, err := idep.NewHealthServiceQuery("webapp")
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -1455,7 +1456,7 @@ func TestTemplate_Execute(t *testing.T) {
 					`{{.CertPEM}}{{.PrivateKeyPEM}}{{end}}`,
 			},
 			func() *Store {
-				d := dep.NewConnectLeafQuery("foo")
+				d := idep.NewConnectLeafQuery("foo")
 				st := NewStore()
 				st.Save(d.String(), &api.LeafCert{
 					Service:       "foo",
@@ -1473,7 +1474,7 @@ func TestTemplate_Execute(t *testing.T) {
 				Contents: `{{range caRoots}}{{.RootCertPEM}}{{end}}`,
 			},
 			func() *Store {
-				d := dep.NewConnectCAQuery()
+				d := idep.NewConnectCAQuery()
 				st := NewStore()
 				st.Save(d.String(), []*api.CARoot{
 					{
@@ -1494,7 +1495,7 @@ func TestTemplate_Execute(t *testing.T) {
 			},
 			func() *Store {
 				st := NewStore()
-				d, err := dep.NewHealthConnectQuery("webapp")
+				d, err := idep.NewHealthConnectQuery("webapp")
 				if err != nil {
 					t.Fatal(err)
 				}


### PR DESCRIPTION
Template functions that return data structures laid out in internal/dependency/ cannot be referenced by products using the library as they are internal only. They need to reference them as they are returned by the template functions where you might want to add additional functions that take those and filter them (like byMeta in consul-template).

This only exposes the internal structures that are returned by a template funcion or are referenced by (field value type) a returned struct.

Fixes: #17 