### PR TITLE
standard library of template functions

### DIFF
--- a/tfunc/consul.go
+++ b/tfunc/consul.go
@@ -1,0 +1,123 @@
+package tfunc
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/hcat/dep"
+	"github.com/pkg/errors"
+)
+
+// byMeta returns Services grouped by one or many ServiceMeta fields.
+func byMeta(meta string, services []*dep.HealthService) (groups map[string][]*dep.HealthService, err error) {
+	re := regexp.MustCompile("[^a-zA-Z0-9_-]")
+	normalize := func(x string) string {
+		return re.ReplaceAllString(x, "_")
+	}
+	getOrDefault := func(m map[string]string, key string) string {
+		realKey := strings.TrimSuffix(key, "|int")
+		if val := m[realKey]; val != "" {
+			return val
+		}
+		if strings.HasSuffix(key, "|int") {
+			return "0"
+		}
+		return fmt.Sprintf("_no_%s_", realKey)
+	}
+
+	metas := strings.Split(meta, ",")
+
+	groups = make(map[string][]*dep.HealthService)
+
+	for _, s := range services {
+		sm := s.ServiceMeta
+		keyParts := []string{}
+		for _, meta := range metas {
+			value := getOrDefault(sm, meta)
+			if strings.HasSuffix(meta, "|int") {
+				value = getOrDefault(sm, meta)
+				i, err := strconv.Atoi(value)
+				if err != nil {
+					return nil, errors.Wrap(err, fmt.Sprintf("cannot parse %v as number ", value))
+				}
+				value = fmt.Sprintf("%05d", i)
+			}
+			keyParts = append(keyParts, normalize(value))
+		}
+		key := strings.Join(keyParts, "_")
+		groups[key] = append(groups[key], s)
+	}
+
+	return groups, nil
+}
+
+// byKey accepts a slice of KV pairs and returns a map of the top-level
+// key to all its subkeys. For example:
+//
+//		elasticsearch/a //=> "1"
+//		elasticsearch/b //=> "2"
+//		redis/a/b //=> "3"
+//
+// Passing the result from Consul through byTag would yield:
+//
+// 		map[string]map[string]string{
+//	  	"elasticsearch": &dep.KeyPair{"a": "1"}, &dep.KeyPair{"b": "2"},
+//			"redis": &dep.KeyPair{"a/b": "3"}
+//		}
+//
+// Note that the top-most key is stripped from the Key value. Keys that have no
+// prefix after stripping are removed from the list.
+func byKey(pairs []*dep.KeyPair) (map[string]map[string]*dep.KeyPair, error) {
+	m := make(map[string]map[string]*dep.KeyPair)
+	for _, pair := range pairs {
+		parts := strings.Split(pair.Key, "/")
+		top := parts[0]
+		key := strings.Join(parts[1:], "/")
+
+		if key == "" {
+			// Do not add a key if it has no prefix after stripping.
+			continue
+		}
+
+		if _, ok := m[top]; !ok {
+			m[top] = make(map[string]*dep.KeyPair)
+		}
+
+		newPair := *pair
+		newPair.Key = key
+		m[top][key] = &newPair
+	}
+
+	return m, nil
+}
+
+// byTag is a template func that takes the provided services and
+// produces a map based on Service tags.
+//
+// The map key is a string representing the service tag. The map value is a
+// slice of Services which have the tag assigned.
+func byTag(in interface{}) (map[string][]interface{}, error) {
+	m := make(map[string][]interface{})
+
+	switch typed := in.(type) {
+	case nil:
+	case []*dep.CatalogSnippet:
+		for _, s := range typed {
+			for _, t := range s.Tags {
+				m[t] = append(m[t], s)
+			}
+		}
+	case []*dep.HealthService:
+		for _, s := range typed {
+			for _, t := range s.Tags {
+				m[t] = append(m[t], s)
+			}
+		}
+	default:
+		return nil, fmt.Errorf("byTag: wrong argument type %T", in)
+	}
+
+	return m, nil
+}

--- a/tfunc/consul_test.go
+++ b/tfunc/consul_test.go
@@ -1,0 +1,197 @@
+package tfunc
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/hcat"
+	"github.com/hashicorp/hcat/dep"
+)
+
+func Test_byMeta(t *testing.T) {
+	t.Parallel()
+	svcA := &dep.HealthService{
+		ServiceMeta: map[string]string{
+			"version":         "v2",
+			"version_num":     "2",
+			"bad_version_num": "1zz",
+			"env":             "dev",
+		},
+		ID: "svcA",
+	}
+
+	svcB := &dep.HealthService{
+		ServiceMeta: map[string]string{
+			"version":         "v11",
+			"version_num":     "11",
+			"bad_version_num": "1zz",
+			"env":             "prod",
+		},
+		ID: "svcB",
+	}
+
+	svcC := &dep.HealthService{
+		ServiceMeta: map[string]string{
+			"version":         "v11",
+			"version_num":     "11",
+			"bad_version_num": "1zz",
+			"env":             "prod",
+		},
+		ID: "svcC",
+	}
+
+	type args struct {
+		meta     string
+		services []*dep.HealthService
+	}
+
+	tests := []struct {
+		name       string
+		args       args
+		wantGroups map[string][]*dep.HealthService
+		wantErr    bool
+	}{
+		{
+			name: "version string",
+			args: args{
+				meta:     "version",
+				services: []*dep.HealthService{svcA, svcB, svcC},
+			},
+			wantGroups: map[string][]*dep.HealthService{
+				"v11": {svcB, svcC},
+				"v2":  {svcA},
+			},
+			wantErr: false,
+		},
+		{
+			name: "version number",
+			args: args{
+				meta:     "version_num|int",
+				services: []*dep.HealthService{svcA, svcB, svcC},
+			},
+			wantGroups: map[string][]*dep.HealthService{
+				"00011": {svcB, svcC},
+				"00002": {svcA},
+			},
+			wantErr: false,
+		},
+		{
+			name: "bad version number",
+			args: args{
+				meta:     "bad_version_num|int",
+				services: []*dep.HealthService{svcA, svcB, svcC},
+			},
+			wantGroups: nil,
+			wantErr:    true,
+		},
+		{
+			name: "multiple meta",
+			args: args{
+				meta:     "env,version_num|int,version",
+				services: []*dep.HealthService{svcA, svcB, svcC},
+			},
+			wantGroups: map[string][]*dep.HealthService{
+				"dev_00002_v2":   {svcA},
+				"prod_00011_v11": {svcB, svcC},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotGroups, err := byMeta(tt.args.meta, tt.args.services)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("byMeta() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			onlyIDs := func(groups map[string][]*dep.HealthService) (ids map[string]map[string]int) {
+				ids = make(map[string]map[string]int)
+				for group, svcs := range groups {
+					ids[group] = make(map[string]int)
+					for _, svc := range svcs {
+						ids[group][svc.ID] = 1
+					}
+				}
+				return
+			}
+
+			gotIDs := onlyIDs(gotGroups)
+			wantIDs := onlyIDs(tt.wantGroups)
+			if !reflect.DeepEqual(gotGroups, tt.wantGroups) {
+				t.Errorf("byMeta() = %v, want %v", gotIDs, wantIDs)
+			}
+		})
+	}
+}
+
+func TestConsulExecute(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		ti   hcat.TemplateInput
+		i    hcat.Recaller
+		e    string
+		err  bool
+	}{
+		// helpers
+		{
+			"helper_by_key",
+			hcat.TemplateInput{
+				Contents: `{{ range $key, $pairs := tree "list" | byKey }}{{ $key }}:{{ range $pairs }}{{ .Key }}={{ .Value }}{{ end }}{{ end }}`,
+			},
+			func() *hcat.Store {
+				st := hcat.NewStore()
+				id := testKVListQueryID("list")
+				st.Save(id, []*dep.KeyPair{
+					{Key: "", Value: ""},
+					{Key: "foo/bar", Value: "a"},
+					{Key: "zip/zap", Value: "b"},
+				})
+				return st
+			}(),
+			"foo:bar=azip:zap=b",
+			false,
+		},
+		{
+			"helper_by_tag",
+			hcat.TemplateInput{
+				Contents: `{{ range $tag, $services := service "webapp" | byTag }}{{ $tag }}:{{ range $services }}{{ .Address }}{{ end }}{{ end }}`,
+			},
+			func() *hcat.Store {
+				st := hcat.NewStore()
+				id := testHealthServiceQueryID("webapp")
+				st.Save(id, []*dep.HealthService{
+					{
+						Address: "1.2.3.4",
+						Tags:    []string{"prod", "staging"},
+					},
+					{
+						Address: "5.6.7.8",
+						Tags:    []string{"staging"},
+					},
+				})
+				return st
+			}(),
+			"prod:1.2.3.4staging:1.2.3.45.6.7.8",
+			false,
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
+			tpl := NewTemplate(tc.ti)
+
+			a, err := tpl.Execute(tc.i)
+			if (err != nil) != tc.err {
+				t.Fatal(err)
+			}
+			if a != nil && !bytes.Equal([]byte(tc.e), a.Output) {
+				t.Errorf("\nexp: %#v\nact: %#v", tc.e, string(a.Output))
+			}
+		})
+	}
+}

--- a/tfunc/contains.go
+++ b/tfunc/contains.go
@@ -1,0 +1,87 @@
+package tfunc
+
+import (
+	"reflect"
+	"strings"
+)
+
+// contains is a function that have reverse arguments of "in" and is designed to
+// be used as a pipe instead of a function:
+//
+// 		{{ l | contains "thing" }}
+//
+func contains(v, l interface{}) (bool, error) {
+	return in(l, v)
+}
+
+// containsSomeFunc returns functions to implement each of the following:
+//
+// 1. containsAll    - true if (∀x ∈ v then x ∈ l); false otherwise
+// 2. containsAny    - true if (∃x ∈ v such that x ∈ l); false otherwise
+// 3. containsNone   - true if (∀x ∈ v then x ∉ l); false otherwise
+// 2. containsNotAll - true if (∃x ∈ v such that x ∉ l); false otherwise
+//
+// ret_true - return true at end of loop for none/all; false for any/notall
+// invert   - invert block test for all/notall
+func containsSomeFunc(retTrue, invert bool) func([]interface{}, interface{}) (bool, error) {
+	return func(v []interface{}, l interface{}) (bool, error) {
+		for i := 0; i < len(v); i++ {
+			if ok, _ := in(l, v[i]); ok != invert {
+				return !retTrue, nil
+			}
+		}
+		return retTrue, nil
+	}
+}
+
+// in searches for a given value in a given interface.
+func in(l, v interface{}) (bool, error) {
+	lv := reflect.ValueOf(l)
+	vv := reflect.ValueOf(v)
+
+	switch lv.Kind() {
+	case reflect.Array, reflect.Slice:
+		// if the slice contains 'interface' elements, then the element needs to be extracted directly to examine its type,
+		// otherwise it will just resolve to 'interface'.
+		var interfaceSlice []interface{}
+		if reflect.TypeOf(l).Elem().Kind() == reflect.Interface {
+			interfaceSlice = l.([]interface{})
+		}
+
+		for i := 0; i < lv.Len(); i++ {
+			var lvv reflect.Value
+			if interfaceSlice != nil {
+				lvv = reflect.ValueOf(interfaceSlice[i])
+			} else {
+				lvv = lv.Index(i)
+			}
+
+			switch lvv.Kind() {
+			case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+				switch vv.Kind() {
+				case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+					if vv.Int() == lvv.Int() {
+						return true, nil
+					}
+				}
+			case reflect.Float32, reflect.Float64:
+				switch vv.Kind() {
+				case reflect.Float32, reflect.Float64:
+					if vv.Float() == lvv.Float() {
+						return true, nil
+					}
+				}
+			case reflect.String:
+				if vv.Type() == lvv.Type() && vv.String() == lvv.String() {
+					return true, nil
+				}
+			}
+		}
+	case reflect.String:
+		if vv.Type() == lv.Type() && strings.Contains(lv.String(), vv.String()) {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}

--- a/tfunc/contains_test.go
+++ b/tfunc/contains_test.go
@@ -1,0 +1,244 @@
+package tfunc
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/hcat"
+	"github.com/hashicorp/hcat/dep"
+)
+
+func TestContainsExecute(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		ti   hcat.TemplateInput
+		i    hcat.Recaller
+		e    string
+		err  bool
+	}{
+		{
+			"helper_contains",
+			hcat.TemplateInput{
+				Contents: `{{ range service "webapp" }}{{ if .Tags | contains "prod" }}{{ .Address }}{{ end }}{{ end }}`,
+			},
+			func() *hcat.Store {
+				st := hcat.NewStore()
+				id := testHealthServiceQueryID("webapp")
+				st.Save(id, []*dep.HealthService{
+					{
+						Address: "1.2.3.4",
+						Tags:    []string{"prod", "staging"},
+					},
+					{
+						Address: "5.6.7.8",
+						Tags:    []string{"staging"},
+					},
+				})
+				return st
+			}(),
+			"1.2.3.4",
+			false,
+		},
+		{
+			"helper_containsAll",
+			hcat.TemplateInput{
+				Contents: `{{ $requiredTags := parseJSON "[\"prod\",\"us-realm\"]" }}{{ range service "webapp" }}{{ if .Tags | containsAll $requiredTags }}{{ .Address }}{{ end }}{{ end }}`,
+			},
+			func() *hcat.Store {
+				st := hcat.NewStore()
+				id := testHealthServiceQueryID("webapp")
+				st.Save(id, []*dep.HealthService{
+					{
+						Address: "1.2.3.4",
+						Tags:    []string{"prod", "us-realm"},
+					},
+					{
+						Address: "5.6.7.8",
+						Tags:    []string{"prod", "ca-realm"},
+					},
+				})
+				return st
+			}(),
+			"1.2.3.4",
+			false,
+		},
+		{
+			"helper_containsAll__empty",
+			hcat.TemplateInput{
+				Contents: `{{ $requiredTags := parseJSON "[]" }}{{ range service "webapp" }}{{ if .Tags | containsAll $requiredTags }}{{ .Address }}{{ end }}{{ end }}`,
+			},
+			func() *hcat.Store {
+				st := hcat.NewStore()
+				id := testHealthServiceQueryID("webapp")
+				st.Save(id, []*dep.HealthService{
+					{
+						Address: "1.2.3.4",
+						Tags:    []string{"prod", "us-realm"},
+					},
+					{
+						Address: "5.6.7.8",
+						Tags:    []string{"prod", "ca-realm"},
+					},
+				})
+				return st
+			}(),
+			"1.2.3.45.6.7.8",
+			false,
+		},
+		{
+			"helper_containsAny",
+			hcat.TemplateInput{
+				Contents: `{{ $acceptableTags := parseJSON "[\"v2\",\"v3\"]" }}{{ range service "webapp" }}{{ if .Tags | containsAny $acceptableTags }}{{ .Address }}{{ end }}{{ end }}`,
+			},
+			func() *hcat.Store {
+				st := hcat.NewStore()
+				id := testHealthServiceQueryID("webapp")
+				st.Save(id, []*dep.HealthService{
+					{
+						Address: "1.2.3.4",
+						Tags:    []string{"prod", "v1"},
+					},
+					{
+						Address: "5.6.7.8",
+						Tags:    []string{"prod", "v2"},
+					},
+				})
+				return st
+			}(),
+			"5.6.7.8",
+			false,
+		},
+		{
+			"helper_containsAny__empty",
+			hcat.TemplateInput{
+				Contents: `{{ $acceptableTags := parseJSON "[]" }}{{ range service "webapp" }}{{ if .Tags | containsAny $acceptableTags }}{{ .Address }}{{ end }}{{ end }}`,
+			},
+			func() *hcat.Store {
+				st := hcat.NewStore()
+				id := testHealthServiceQueryID("webapp")
+				st.Save(id, []*dep.HealthService{
+					{
+						Address: "1.2.3.4",
+						Tags:    []string{"prod", "v1"},
+					},
+					{
+						Address: "5.6.7.8",
+						Tags:    []string{"prod", "v2"},
+					},
+				})
+				return st
+			}(),
+			"",
+			false,
+		},
+		{
+			"helper_containsNone",
+			hcat.TemplateInput{
+				Contents: `{{ $forbiddenTags := parseJSON "[\"devel\",\"staging\"]" }}{{ range service "webapp" }}{{ if .Tags | containsNone $forbiddenTags }}{{ .Address }}{{ end }}{{ end }}`,
+			},
+			func() *hcat.Store {
+				st := hcat.NewStore()
+				id := testHealthServiceQueryID("webapp")
+				st.Save(id, []*dep.HealthService{
+					{
+						Address: "1.2.3.4",
+						Tags:    []string{"prod", "v1"},
+					},
+					{
+						Address: "5.6.7.8",
+						Tags:    []string{"devel", "v2"},
+					},
+				})
+				return st
+			}(),
+			"1.2.3.4",
+			false,
+		},
+		{
+			"helper_containsNone__empty",
+			hcat.TemplateInput{
+				Contents: `{{ $forbiddenTags := parseJSON "[]" }}{{ range service "webapp" }}{{ if .Tags | containsNone $forbiddenTags }}{{ .Address }}{{ end }}{{ end }}`,
+			},
+			func() *hcat.Store {
+				st := hcat.NewStore()
+				id := testHealthServiceQueryID("webapp")
+				st.Save(id, []*dep.HealthService{
+					{
+						Address: "1.2.3.4",
+						Tags:    []string{"staging", "v1"},
+					},
+					{
+						Address: "5.6.7.8",
+						Tags:    []string{"devel", "v2"},
+					},
+				})
+				return st
+			}(),
+			"1.2.3.45.6.7.8",
+			false,
+		},
+		{
+			"helper_containsNotAll",
+			hcat.TemplateInput{
+				Contents: `{{ $excludingTags := parseJSON "[\"es-v1\",\"es-v2\"]" }}{{ range service "webapp" }}{{ if .Tags | containsNotAll $excludingTags }}{{ .Address }}{{ end }}{{ end }}`,
+			},
+			func() *hcat.Store {
+				st := hcat.NewStore()
+				id := testHealthServiceQueryID("webapp")
+				st.Save(id, []*dep.HealthService{
+					{
+						Address: "1.2.3.4",
+						Tags:    []string{"prod", "es-v1"},
+					},
+					{
+						Address: "5.6.7.8",
+						Tags:    []string{"prod", "hybrid", "es-v1", "es-v2"},
+					},
+				})
+				return st
+			}(),
+			"1.2.3.4",
+			false,
+		},
+		{
+			"helper_containsNotAll__empty",
+			hcat.TemplateInput{
+				Contents: `{{ $excludingTags := parseJSON "[]" }}{{ range service "webapp" }}{{ if .Tags | containsNotAll $excludingTags }}{{ .Address }}{{ end }}{{ end }}`,
+			},
+			func() *hcat.Store {
+				st := hcat.NewStore()
+				id := testHealthServiceQueryID("webapp")
+				st.Save(id, []*dep.HealthService{
+					{
+						Address: "1.2.3.4",
+						Tags:    []string{"prod", "es-v1"},
+					},
+					{
+						Address: "5.6.7.8",
+						Tags:    []string{"prod", "hybrid", "es-v1", "es-v2"},
+					},
+				})
+				return st
+			}(),
+			"",
+			false,
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
+			tpl := NewTemplate(tc.ti)
+
+			a, err := tpl.Execute(tc.i)
+			if (err != nil) != tc.err {
+				t.Fatal(err)
+			}
+			if a != nil && !bytes.Equal([]byte(tc.e), a.Output) {
+				t.Errorf("\nexp: %#v\nact: %#v", tc.e, string(a.Output))
+			}
+		})
+	}
+}

--- a/tfunc/env.go
+++ b/tfunc/env.go
@@ -1,0 +1,22 @@
+package tfunc
+
+import (
+	"os"
+	"strings"
+)
+
+// envFunc returns a function which checks the value of an environment variable.
+// Invokers can specify their own environment, which takes precedences over any
+// real environment variables
+func envFunc(env []string) func(string) (string, error) {
+	return func(s string) (string, error) {
+		for _, e := range env {
+			split := strings.SplitN(e, "=", 2)
+			k, v := split[0], split[1]
+			if k == s {
+				return v, nil
+			}
+		}
+		return os.Getenv(s), nil
+	}
+}

--- a/tfunc/env_test.go
+++ b/tfunc/env_test.go
@@ -1,0 +1,53 @@
+package tfunc
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/hcat"
+)
+
+func TestEnvExecute(t *testing.T) {
+	t.Parallel()
+
+	// set an environment variable for the tests
+	if err := os.Setenv("CT_TEST", "1"); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { os.Unsetenv("CT_TEST") }()
+
+	cases := []struct {
+		name string
+		ti   hcat.TemplateInput
+		i    hcat.Recaller
+		e    string
+		err  bool
+	}{
+		{
+			"helper_env",
+			hcat.TemplateInput{
+				// CT_TEST set above
+				Contents: `{{ env "CT_TEST" }}`,
+			},
+			hcat.NewStore(),
+			"1",
+			false,
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
+			tpl := NewTemplate(tc.ti)
+
+			a, err := tpl.Execute(tc.i)
+			if (err != nil) != tc.err {
+				t.Fatal(err)
+			}
+			if a != nil && !bytes.Equal([]byte(tc.e), a.Output) {
+				t.Errorf("\nexp: %#v\nact: %#v", tc.e, string(a.Output))
+			}
+		})
+	}
+}

--- a/tfunc/explode.go
+++ b/tfunc/explode.go
@@ -1,0 +1,63 @@
+package tfunc
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/hashicorp/hcat/dep"
+	"github.com/pkg/errors"
+)
+
+// explode is used to expand a list of keypairs into a deeply-nested hash.
+func explode(pairs []*dep.KeyPair) (map[string]interface{}, error) {
+	m := make(map[string]interface{})
+	for _, pair := range pairs {
+		if err := explodeHelper(m, pair.Key, pair.Value, pair.Key); err != nil {
+			return nil, errors.Wrap(err, "explode")
+		}
+	}
+	return m, nil
+}
+
+// explodeHelper is a recursive helper for explode and explodeMap
+func explodeHelper(m map[string]interface{}, k string, v interface{}, p string) error {
+	if strings.Contains(k, "/") {
+		parts := strings.Split(k, "/")
+		top := parts[0]
+		key := strings.Join(parts[1:], "/")
+
+		if _, ok := m[top]; !ok {
+			m[top] = make(map[string]interface{})
+		}
+		nest, ok := m[top].(map[string]interface{})
+		if !ok {
+			return fmt.Errorf("not a map: %q: %q already has value %q", p, top, m[top])
+		}
+		return explodeHelper(nest, key, v, k)
+	}
+
+	if k != "" {
+		m[k] = v
+	}
+
+	return nil
+}
+
+// explodeMap turns a single-level map into a deeply-nested hash.
+func explodeMap(mapIn map[string]interface{}) (map[string]interface{}, error) {
+	mapOut := make(map[string]interface{})
+
+	var keys []string
+	for k := range mapIn {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for i := range keys {
+		if err := explodeHelper(mapOut, keys[i], mapIn[keys[i]], keys[i]); err != nil {
+			return nil, errors.Wrap(err, "explodeMap")
+		}
+	}
+	return mapOut, nil
+}

--- a/tfunc/explode_test.go
+++ b/tfunc/explode_test.go
@@ -1,0 +1,64 @@
+package tfunc
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/hcat"
+	"github.com/hashicorp/hcat/dep"
+)
+
+func TestExplodeExecute(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		ti   hcat.TemplateInput
+		i    hcat.Recaller
+		e    string
+		err  bool
+	}{
+		{
+			"helper_explode",
+			hcat.TemplateInput{
+				Contents: `{{ range $k, $v := tree "list" | explode }}{{ $k }}{{ $v }}{{ end }}`,
+			},
+			func() *hcat.Store {
+				st := hcat.NewStore()
+				id := testKVListQueryID("list")
+				st.Save(id, []*dep.KeyPair{
+					{Key: "", Value: ""},
+					{Key: "foo/bar", Value: "a"},
+					{Key: "zip/zap", Value: "b"},
+				})
+				return st
+			}(),
+			"foomap[bar:a]zipmap[zap:b]",
+			false,
+		},
+		{
+			"helper_explodemap",
+			hcat.TemplateInput{
+				Contents: `{{ scratch.MapSet "explode-test" "foo/bar" "a"}}{{ scratch.MapSet "explode-test" "qux" "c"}}{{ scratch.MapSet "explode-test" "zip/zap" "d"}}{{ scratch.Get "explode-test" | explodeMap }}`,
+			},
+			hcat.NewStore(),
+			"map[foo:map[bar:a] qux:c zip:map[zap:d]]",
+			false,
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
+			tpl := NewTemplate(tc.ti)
+
+			a, err := tpl.Execute(tc.i)
+			if (err != nil) != tc.err {
+				t.Fatal(err)
+			}
+			if a != nil && !bytes.Equal([]byte(tc.e), a.Output) {
+				t.Errorf("\nexp: %#v\nact: %#v", tc.e, string(a.Output))
+			}
+		})
+	}
+}

--- a/tfunc/loop.go
+++ b/tfunc/loop.go
@@ -1,0 +1,71 @@
+package tfunc
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// loop accepts varying parameters and differs its behavior. If given one
+// parameter, loop will return a goroutine that begins at 0 and loops until the
+// given int, increasing the index by 1 each iteration. If given two parameters,
+// loop will return a goroutine that begins at the first parameter and loops
+// up to but not including the second parameter.
+//
+//    // Prints 0 1 2 3 4
+// 		for _, i := range loop(5) {
+// 			print(i)
+// 		}
+//
+//    // Prints 5 6 7
+// 		for _, i := range loop(5, 8) {
+// 			print(i)
+// 		}
+//
+func loop(ifaces ...interface{}) (<-chan int64, error) {
+
+	to64 := func(i interface{}) (int64, error) {
+		v := reflect.ValueOf(i)
+		switch v.Kind() {
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32,
+			reflect.Int64:
+			return int64(v.Int()), nil
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32,
+			reflect.Uint64:
+			return int64(v.Uint()), nil
+		case reflect.String:
+			return parseInt(v.String())
+		}
+		return 0, fmt.Errorf("loop: bad argument type: %T", i)
+	}
+
+	var i1, i2 interface{}
+	switch len(ifaces) {
+	case 1:
+		i1, i2 = 0, ifaces[0]
+	case 2:
+		i1, i2 = ifaces[0], ifaces[1]
+	default:
+		return nil, fmt.Errorf("loop: wrong number of arguments, expected "+
+			"1 or 2, but got %d", len(ifaces))
+	}
+
+	start, err := to64(i1)
+	if err != nil {
+		return nil, err
+	}
+	stop, err := to64(i2)
+	if err != nil {
+		return nil, err
+	}
+
+	ch := make(chan int64)
+
+	go func() {
+		for i := start; i < stop; i++ {
+			ch <- i
+		}
+		close(ch)
+	}()
+
+	return ch, nil
+}

--- a/tfunc/loop_test.go
+++ b/tfunc/loop_test.go
@@ -1,0 +1,92 @@
+package tfunc
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/hcat"
+)
+
+func TestLoopExecute(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		ti   hcat.TemplateInput
+		i    hcat.Recaller
+		e    string
+		err  bool
+	}{
+		{
+			"helper_loop",
+			hcat.TemplateInput{
+				Contents: `{{ range loop 3 }}1{{ end }}`,
+			},
+			hcat.NewStore(),
+			"111",
+			false,
+		},
+		{
+			"helper_loop__i",
+			hcat.TemplateInput{
+				Contents: `{{ range $i := loop 3 }}{{ $i }}{{ end }}`,
+			},
+			hcat.NewStore(),
+			"012",
+			false,
+		},
+		{
+			"helper_loop_start",
+			hcat.TemplateInput{
+				Contents: `{{ range loop 1 3 }}1{{ end }}`,
+			},
+			hcat.NewStore(),
+			"11",
+			false,
+		},
+		{
+			"helper_loop_text",
+			hcat.TemplateInput{
+				Contents: `{{ range loop 1 "3" }}1{{ end }}`,
+			},
+			hcat.NewStore(),
+			"11",
+			false,
+		},
+		{
+			"helper_loop_parseInt",
+			hcat.TemplateInput{
+				Contents: `{{ $i := print "3" | parseInt }}{{ range loop 1 $i }}1{{ end }}`,
+			},
+			hcat.NewStore(),
+			"11",
+			false,
+		},
+		{
+			// GH-1143
+			"helper_loop_var",
+			hcat.TemplateInput{
+				Contents: `{{$n := 3 }}` +
+					`{{ range $i := loop $n }}{{ $i }}{{ end }}`,
+			},
+			hcat.NewStore(),
+			"012",
+			false,
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
+			tpl := NewTemplate(tc.ti)
+
+			a, err := tpl.Execute(tc.i)
+			if (err != nil) != tc.err {
+				t.Fatal(err)
+			}
+			if a != nil && !bytes.Equal([]byte(tc.e), a.Output) {
+				t.Errorf("\nexp: %#v\nact: %#v", tc.e, string(a.Output))
+			}
+		})
+	}
+}

--- a/tfunc/math.go
+++ b/tfunc/math.go
@@ -1,0 +1,353 @@
+package tfunc
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// add returns the sum of a and b.
+func add(b, a interface{}) (interface{}, error) {
+	av := reflect.ValueOf(a)
+	bv := reflect.ValueOf(b)
+
+	switch av.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		switch bv.Kind() {
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			return av.Int() + bv.Int(), nil
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			return av.Int() + int64(bv.Uint()), nil
+		case reflect.Float32, reflect.Float64:
+			return float64(av.Int()) + bv.Float(), nil
+		default:
+			return nil, fmt.Errorf("add: unknown type for %q (%T)", bv, b)
+		}
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		switch bv.Kind() {
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			return int64(av.Uint()) + bv.Int(), nil
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			return av.Uint() + bv.Uint(), nil
+		case reflect.Float32, reflect.Float64:
+			return float64(av.Uint()) + bv.Float(), nil
+		default:
+			return nil, fmt.Errorf("add: unknown type for %q (%T)", bv, b)
+		}
+	case reflect.Float32, reflect.Float64:
+		switch bv.Kind() {
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			return av.Float() + float64(bv.Int()), nil
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			return av.Float() + float64(bv.Uint()), nil
+		case reflect.Float32, reflect.Float64:
+			return av.Float() + bv.Float(), nil
+		default:
+			return nil, fmt.Errorf("add: unknown type for %q (%T)", bv, b)
+		}
+	default:
+		return nil, fmt.Errorf("add: unknown type for %q (%T)", av, a)
+	}
+}
+
+// subtract returns the difference of b from a.
+func subtract(b, a interface{}) (interface{}, error) {
+	av := reflect.ValueOf(a)
+	bv := reflect.ValueOf(b)
+
+	switch av.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		switch bv.Kind() {
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			return av.Int() - bv.Int(), nil
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			return av.Int() - int64(bv.Uint()), nil
+		case reflect.Float32, reflect.Float64:
+			return float64(av.Int()) - bv.Float(), nil
+		default:
+			return nil, fmt.Errorf("subtract: unknown type for %q (%T)", bv, b)
+		}
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		switch bv.Kind() {
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			return int64(av.Uint()) - bv.Int(), nil
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			return av.Uint() - bv.Uint(), nil
+		case reflect.Float32, reflect.Float64:
+			return float64(av.Uint()) - bv.Float(), nil
+		default:
+			return nil, fmt.Errorf("subtract: unknown type for %q (%T)", bv, b)
+		}
+	case reflect.Float32, reflect.Float64:
+		switch bv.Kind() {
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			return av.Float() - float64(bv.Int()), nil
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			return av.Float() - float64(bv.Uint()), nil
+		case reflect.Float32, reflect.Float64:
+			return av.Float() - bv.Float(), nil
+		default:
+			return nil, fmt.Errorf("subtract: unknown type for %q (%T)", bv, b)
+		}
+	default:
+		return nil, fmt.Errorf("subtract: unknown type for %q (%T)", av, a)
+	}
+}
+
+// multiply returns the product of a and b.
+func multiply(b, a interface{}) (interface{}, error) {
+	av := reflect.ValueOf(a)
+	bv := reflect.ValueOf(b)
+
+	switch av.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		switch bv.Kind() {
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			return av.Int() * bv.Int(), nil
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			return av.Int() * int64(bv.Uint()), nil
+		case reflect.Float32, reflect.Float64:
+			return float64(av.Int()) * bv.Float(), nil
+		default:
+			return nil, fmt.Errorf("multiply: unknown type for %q (%T)", bv, b)
+		}
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		switch bv.Kind() {
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			return int64(av.Uint()) * bv.Int(), nil
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			return av.Uint() * bv.Uint(), nil
+		case reflect.Float32, reflect.Float64:
+			return float64(av.Uint()) * bv.Float(), nil
+		default:
+			return nil, fmt.Errorf("multiply: unknown type for %q (%T)", bv, b)
+		}
+	case reflect.Float32, reflect.Float64:
+		switch bv.Kind() {
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			return av.Float() * float64(bv.Int()), nil
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			return av.Float() * float64(bv.Uint()), nil
+		case reflect.Float32, reflect.Float64:
+			return av.Float() * bv.Float(), nil
+		default:
+			return nil, fmt.Errorf("multiply: unknown type for %q (%T)", bv, b)
+		}
+	default:
+		return nil, fmt.Errorf("multiply: unknown type for %q (%T)", av, a)
+	}
+}
+
+// divide returns the division of b from a.
+func divide(b, a interface{}) (interface{}, error) {
+	av := reflect.ValueOf(a)
+	bv := reflect.ValueOf(b)
+
+	switch av.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		switch bv.Kind() {
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			return av.Int() / bv.Int(), nil
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			return av.Int() / int64(bv.Uint()), nil
+		case reflect.Float32, reflect.Float64:
+			return float64(av.Int()) / bv.Float(), nil
+		default:
+			return nil, fmt.Errorf("divide: unknown type for %q (%T)", bv, b)
+		}
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		switch bv.Kind() {
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			return int64(av.Uint()) / bv.Int(), nil
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			return av.Uint() / bv.Uint(), nil
+		case reflect.Float32, reflect.Float64:
+			return float64(av.Uint()) / bv.Float(), nil
+		default:
+			return nil, fmt.Errorf("divide: unknown type for %q (%T)", bv, b)
+		}
+	case reflect.Float32, reflect.Float64:
+		switch bv.Kind() {
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			return av.Float() / float64(bv.Int()), nil
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			return av.Float() / float64(bv.Uint()), nil
+		case reflect.Float32, reflect.Float64:
+			return av.Float() / bv.Float(), nil
+		default:
+			return nil, fmt.Errorf("divide: unknown type for %q (%T)", bv, b)
+		}
+	default:
+		return nil, fmt.Errorf("divide: unknown type for %q (%T)", av, a)
+	}
+}
+
+// modulo returns the modulo of b from a.
+func modulo(b, a interface{}) (interface{}, error) {
+	av := reflect.ValueOf(a)
+	bv := reflect.ValueOf(b)
+
+	switch av.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		switch bv.Kind() {
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			return av.Int() % bv.Int(), nil
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			return av.Int() % int64(bv.Uint()), nil
+		default:
+			return nil, fmt.Errorf("modulo: unknown type for %q (%T)", bv, b)
+		}
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		switch bv.Kind() {
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			return int64(av.Uint()) % bv.Int(), nil
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			return av.Uint() % bv.Uint(), nil
+		default:
+			return nil, fmt.Errorf("modulo: unknown type for %q (%T)", bv, b)
+		}
+	default:
+		return nil, fmt.Errorf("modulo: unknown type for %q (%T)", av, a)
+	}
+}
+
+// minimum returns the minimum between a and b.
+func minimum(b, a interface{}) (interface{}, error) {
+	av := reflect.ValueOf(a)
+	bv := reflect.ValueOf(b)
+
+	switch av.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		switch bv.Kind() {
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			if av.Int() < bv.Int() {
+				return av.Int(), nil
+			}
+			return bv.Int(), nil
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			if av.Int() < int64(bv.Uint()) {
+				return av.Int(), nil
+			}
+			return bv.Uint(), nil
+		case reflect.Float32, reflect.Float64:
+			if float64(av.Int()) < bv.Float() {
+				return av.Int(), nil
+			}
+			return bv.Float(), nil
+		default:
+			return nil, fmt.Errorf("minimum: unknown type for %q (%T)", bv, b)
+		}
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		switch bv.Kind() {
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			if int64(av.Uint()) < bv.Int() {
+				return av.Uint(), nil
+			}
+			return bv.Int(), nil
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			if av.Uint() < bv.Uint() {
+				return av.Uint(), nil
+			}
+			return bv.Uint(), nil
+		case reflect.Float32, reflect.Float64:
+			if float64(av.Uint()) < bv.Float() {
+				return av.Uint(), nil
+			}
+			return bv.Float(), nil
+		default:
+			return nil, fmt.Errorf("minimum: unknown type for %q (%T)", bv, b)
+		}
+	case reflect.Float32, reflect.Float64:
+		switch bv.Kind() {
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			if av.Float() < float64(bv.Int()) {
+				return av.Float(), nil
+			}
+			return bv.Int(), nil
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			if av.Float() < float64(bv.Uint()) {
+				return av.Float(), nil
+			}
+			return bv.Uint(), nil
+		case reflect.Float32, reflect.Float64:
+			if av.Float() < bv.Float() {
+				return av.Float(), nil
+			}
+			return bv.Float(), nil
+		default:
+			return nil, fmt.Errorf("minimum: unknown type for %q (%T)", bv, b)
+		}
+	default:
+		return nil, fmt.Errorf("minimum: unknown type for %q (%T)", av, a)
+	}
+}
+
+// maximum returns the maximum between a and b.
+func maximum(b, a interface{}) (interface{}, error) {
+	av := reflect.ValueOf(a)
+	bv := reflect.ValueOf(b)
+
+	switch av.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		switch bv.Kind() {
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			if av.Int() > bv.Int() {
+				return av.Int(), nil
+			}
+			return bv.Int(), nil
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			if av.Int() > int64(bv.Uint()) {
+				return av.Int(), nil
+			}
+			return bv.Uint(), nil
+		case reflect.Float32, reflect.Float64:
+			if float64(av.Int()) > bv.Float() {
+				return av.Int(), nil
+			}
+			return bv.Float(), nil
+		default:
+			return nil, fmt.Errorf("maximum: unknown type for %q (%T)", bv, b)
+		}
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		switch bv.Kind() {
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			if int64(av.Uint()) > bv.Int() {
+				return av.Uint(), nil
+			}
+			return bv.Int(), nil
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			if av.Uint() > bv.Uint() {
+				return av.Uint(), nil
+			}
+			return bv.Uint(), nil
+		case reflect.Float32, reflect.Float64:
+			if float64(av.Uint()) > bv.Float() {
+				return av.Uint(), nil
+			}
+			return bv.Float(), nil
+		default:
+			return nil, fmt.Errorf("maximum: unknown type for %q (%T)", bv, b)
+		}
+	case reflect.Float32, reflect.Float64:
+		switch bv.Kind() {
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			if av.Float() > float64(bv.Int()) {
+				return av.Float(), nil
+			}
+			return bv.Int(), nil
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			if av.Float() > float64(bv.Uint()) {
+				return av.Float(), nil
+			}
+			return bv.Uint(), nil
+		case reflect.Float32, reflect.Float64:
+			if av.Float() > bv.Float() {
+				return av.Float(), nil
+			}
+			return bv.Float(), nil
+		default:
+			return nil, fmt.Errorf("maximum: unknown type for %q (%T)", bv, b)
+		}
+	default:
+		return nil, fmt.Errorf("maximum: unknown type for %q (%T)", av, a)
+	}
+}

--- a/tfunc/math_test.go
+++ b/tfunc/math_test.go
@@ -1,0 +1,99 @@
+package tfunc
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/hcat"
+)
+
+func TestMathExecute(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		ti   hcat.TemplateInput
+		i    hcat.Recaller
+		e    string
+		err  bool
+	}{
+		{
+			"math_add",
+			hcat.TemplateInput{
+				Contents: `{{ 2 | add 2 }}`,
+			},
+			hcat.NewStore(),
+			"4",
+			false,
+		},
+		{
+			"math_subtract",
+			hcat.TemplateInput{
+				Contents: `{{ 2 | subtract 2 }}`,
+			},
+			hcat.NewStore(),
+			"0",
+			false,
+		},
+		{
+			"math_multiply",
+			hcat.TemplateInput{
+				Contents: `{{ 2 | multiply 2 }}`,
+			},
+			hcat.NewStore(),
+			"4",
+			false,
+		},
+		{
+			"math_divide",
+			hcat.TemplateInput{
+				Contents: `{{ 2 | divide 2 }}`,
+			},
+			hcat.NewStore(),
+			"1",
+			false,
+		},
+		{
+			"math_modulo",
+			hcat.TemplateInput{
+				Contents: `{{ 3 | modulo 2 }}`,
+			},
+			hcat.NewStore(),
+			"1",
+			false,
+		},
+		{
+			"math_minimum",
+			hcat.TemplateInput{
+				Contents: `{{ 3 | minimum 2 }}`,
+			},
+			hcat.NewStore(),
+			"2",
+			false,
+		},
+		{
+			"math_maximum",
+			hcat.TemplateInput{
+				Contents: `{{ 3 | maximum 2 }}`,
+			},
+			hcat.NewStore(),
+			"3",
+			false,
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
+			tpl := NewTemplate(tc.ti)
+
+			a, err := tpl.Execute(tc.i)
+			if (err != nil) != tc.err {
+				t.Fatal(err)
+			}
+			if a != nil && !bytes.Equal([]byte(tc.e), a.Output) {
+				t.Errorf("\nexp: %#v\nact: %#v", tc.e, string(a.Output))
+			}
+		})
+	}
+}

--- a/tfunc/parse.go
+++ b/tfunc/parse.go
@@ -1,0 +1,87 @@
+package tfunc
+
+import (
+	"encoding/json"
+	"strconv"
+
+	"github.com/pkg/errors"
+	yaml "gopkg.in/yaml.v2"
+)
+
+// parseBool parses a string into a boolean
+func parseBool(s string) (bool, error) {
+	if s == "" {
+		return false, nil
+	}
+
+	result, err := strconv.ParseBool(s)
+	if err != nil {
+		return false, errors.Wrap(err, "parseBool")
+	}
+	return result, nil
+}
+
+// parseFloat parses a string into a base 10 float
+func parseFloat(s string) (float64, error) {
+	if s == "" {
+		return 0.0, nil
+	}
+
+	result, err := strconv.ParseFloat(s, 10)
+	if err != nil {
+		return 0, errors.Wrap(err, "parseFloat")
+	}
+	return result, nil
+}
+
+// parseInt parses a string into a base 10 int
+func parseInt(s string) (int64, error) {
+	if s == "" {
+		return 0, nil
+	}
+
+	result, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return 0, errors.Wrap(err, "parseInt")
+	}
+	return result, nil
+}
+
+// parseJSON returns a structure for valid JSON
+func parseJSON(s string) (interface{}, error) {
+	if s == "" {
+		return map[string]interface{}{}, nil
+	}
+
+	var data interface{}
+	if err := json.Unmarshal([]byte(s), &data); err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+// parseUint parses a string into a base 10 int
+func parseUint(s string) (uint64, error) {
+	if s == "" {
+		return 0, nil
+	}
+
+	result, err := strconv.ParseUint(s, 10, 64)
+	if err != nil {
+		return 0, errors.Wrap(err, "parseUint")
+	}
+	return result, nil
+}
+
+// parseYAML returns a structure for valid YAML
+func parseYAML(s string) (interface{}, error) {
+	if s == "" {
+		return map[string]interface{}{}, nil
+	}
+
+	var data interface{}
+	if err := yaml.Unmarshal([]byte(s), &data); err != nil {
+		return nil, err
+	}
+	return data, nil
+}

--- a/tfunc/parse_test.go
+++ b/tfunc/parse_test.go
@@ -1,0 +1,108 @@
+package tfunc
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/hcat"
+)
+
+func TestParseExecute(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		ti   hcat.TemplateInput
+		i    hcat.Recaller
+		e    string
+		err  bool
+	}{
+		{
+			"parseBool",
+			hcat.TemplateInput{
+				Contents: `{{ "true" | parseBool }}`,
+			},
+			hcat.NewStore(),
+			"true",
+			false,
+		},
+		{
+			"parseFloat",
+			hcat.TemplateInput{
+				Contents: `{{ "1.2" | parseFloat }}`,
+			},
+			hcat.NewStore(),
+			"1.2",
+			false,
+		},
+		{
+			"parseInt",
+			hcat.TemplateInput{
+				Contents: `{{ "-1" | parseInt }}`,
+			},
+			hcat.NewStore(),
+			"-1",
+			false,
+		},
+		{
+			"parseJSON",
+			hcat.TemplateInput{
+				Contents: `{{ "{\"foo\": \"bar\"}" | parseJSON }}`,
+			},
+			hcat.NewStore(),
+			"map[foo:bar]",
+			false,
+		},
+		{
+			"parseUint",
+			hcat.TemplateInput{
+				Contents: `{{ "1" | parseUint }}`,
+			},
+			hcat.NewStore(),
+			"1",
+			false,
+		},
+		{
+			"parseYAML",
+			hcat.TemplateInput{
+				Contents: `{{ "foo: bar" | parseYAML }}`,
+			},
+			hcat.NewStore(),
+			"map[foo:bar]",
+			false,
+		},
+		{
+			"parseYAMLv2",
+			hcat.TemplateInput{
+				Contents: `{{ "foo: bar\nbaz: \"foo\"" | parseYAML }}`,
+			},
+			hcat.NewStore(),
+			"map[baz:foo foo:bar]",
+			false,
+		},
+		{
+			"parseYAMLnested",
+			hcat.TemplateInput{
+				Contents: `{{ "foo:\n  bar: \"baz\"\n  baz: 7" | parseYAML }}`,
+			},
+			hcat.NewStore(),
+			"map[foo:map[bar:baz baz:7]]",
+			false,
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
+			tpl := NewTemplate(tc.ti)
+
+			a, err := tpl.Execute(tc.i)
+			if (err != nil) != tc.err {
+				t.Fatal(err)
+			}
+			if a != nil && !bytes.Equal([]byte(tc.e), a.Output) {
+				t.Errorf("\nexp: %#v\nact: %#v", tc.e, string(a.Output))
+			}
+		})
+	}
+}

--- a/tfunc/sockaddr.go
+++ b/tfunc/sockaddr.go
@@ -1,0 +1,18 @@
+package tfunc
+
+import (
+	"fmt"
+	"strings"
+
+	socktmpl "github.com/hashicorp/go-sockaddr/template"
+)
+
+// sockaddr wraps go-sockaddr templating
+func sockaddr(args ...string) (string, error) {
+	t := fmt.Sprintf("{{ %s }}", strings.Join(args, " "))
+	k, err := socktmpl.Parse(t)
+	if err != nil {
+		return "", err
+	}
+	return k, nil
+}

--- a/tfunc/sockaddr_test.go
+++ b/tfunc/sockaddr_test.go
@@ -1,0 +1,35 @@
+package tfunc
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/hcat"
+)
+
+func TestSockAddrExecute(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		ti   hcat.TemplateInput
+		i    hcat.Recaller
+		e    string
+		err  bool
+	}{}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
+			tpl := NewTemplate(tc.ti)
+
+			a, err := tpl.Execute(tc.i)
+			if (err != nil) != tc.err {
+				t.Fatal(err)
+			}
+			if a != nil && !bytes.Equal([]byte(tc.e), a.Output) {
+				t.Errorf("\nexp: %#v\nact: %#v", tc.e, string(a.Output))
+			}
+		})
+	}
+}

--- a/tfunc/string.go
+++ b/tfunc/string.go
@@ -1,0 +1,74 @@
+package tfunc
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// Indent prefixes each line of a string with the specified number of spaces
+func indent(spaces int, s string) (string, error) {
+	if spaces < 0 {
+		return "", fmt.Errorf("indent value must be a positive integer")
+	}
+	var output, prefix []byte
+	var sp bool
+	var size int
+	prefix = []byte(strings.Repeat(" ", spaces))
+	sp = true
+	for _, c := range []byte(s) {
+		if sp && c != '\n' {
+			output = append(output, prefix...)
+			size += spaces
+		}
+		output = append(output, c)
+		sp = c == '\n'
+		size++
+	}
+	return string(output[:size]), nil
+}
+
+// join is a version of strings.Join that can be piped
+func join(sep string, a []string) (string, error) {
+	return strings.Join(a, sep), nil
+}
+
+// split is a version of strings.Split that can be piped
+func split(sep, s string) ([]string, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return []string{}, nil
+	}
+	return strings.Split(s, sep), nil
+}
+
+// TrimSpace is a version of strings.TrimSpace that can be piped
+func trimSpace(s string) (string, error) {
+	return strings.TrimSpace(s), nil
+}
+
+// replaceAll replaces all occurrences of a value in a string with the given
+// replacement value.
+func replaceAll(f, t, s string) (string, error) {
+	return strings.Replace(s, f, t, -1), nil
+}
+
+// regexReplaceAll replaces all occurrences of a regular expression with
+// the given replacement value.
+func regexReplaceAll(re, pl, s string) (string, error) {
+	compiled, err := regexp.Compile(re)
+	if err != nil {
+		return "", err
+	}
+	return compiled.ReplaceAllString(s, pl), nil
+}
+
+// regexMatch returns true or false if the string matches
+// the given regular expression
+func regexMatch(re, s string) (bool, error) {
+	compiled, err := regexp.Compile(re)
+	if err != nil {
+		return false, err
+	}
+	return compiled.MatchString(s), nil
+}

--- a/tfunc/string_test.go
+++ b/tfunc/string_test.go
@@ -1,0 +1,117 @@
+package tfunc
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/hcat"
+)
+
+func TestStringExecute(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		ti   hcat.TemplateInput
+		i    hcat.Recaller
+		e    string
+		err  bool
+	}{
+		{
+			"indent",
+			hcat.TemplateInput{
+				Contents: `{{ "hello\nhello\r\nHELLO\r\nhello\nHELLO" | indent 4 }}`,
+			},
+			hcat.NewStore(),
+			"    hello\n    hello\r\n    HELLO\r\n    hello\n    HELLO",
+			false,
+		},
+		{
+			"indent_negative",
+			hcat.TemplateInput{
+				Contents: `{{ "hello\nhello\r\nHELLO\r\nhello\nHELLO" | indent -4 }}`,
+			},
+			hcat.NewStore(),
+			"    hello\n    hello\r\n    HELLO\r\n    hello\n    HELLO",
+			true,
+		},
+		{
+			"indent_zero",
+			hcat.TemplateInput{
+				Contents: `{{ "hello\nhello\r\nHELLO\r\nhello\nHELLO" | indent 0 }}`,
+			},
+			hcat.NewStore(),
+			"hello\nhello\r\nHELLO\r\nhello\nHELLO",
+			false,
+		},
+		{
+			"join",
+			hcat.TemplateInput{
+				Contents: `{{ "a,b,c" | split "," | join ";" }}`,
+			},
+			hcat.NewStore(),
+			"a;b;c",
+			false,
+		},
+		{
+			"trimSpace",
+			hcat.TemplateInput{
+				Contents: `{{ "\t hi\n " | trimSpace }}`,
+			},
+			hcat.NewStore(),
+			"hi",
+			false,
+		},
+		{
+			"split",
+			hcat.TemplateInput{
+				Contents: `{{ "a,b,c" | split "," }}`,
+			},
+			hcat.NewStore(),
+			"[a b c]",
+			false,
+		},
+		{
+			"replaceAll",
+			hcat.TemplateInput{
+				Contents: `{{ "hello my hello" | regexReplaceAll "hello" "bye" }}`,
+			},
+			hcat.NewStore(),
+			"bye my bye",
+			false,
+		},
+		{
+			"regexReplaceAll",
+			hcat.TemplateInput{
+				Contents: `{{ "foo" | regexReplaceAll "\\w" "x" }}`,
+			},
+			hcat.NewStore(),
+			"xxx",
+			false,
+		},
+		{
+			"regexMatch",
+			hcat.TemplateInput{
+				Contents: `{{ "foo" | regexMatch "[a-z]+" }}`,
+			},
+			hcat.NewStore(),
+			"true",
+			false,
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
+			tpl := NewTemplate(tc.ti)
+
+			a, err := tpl.Execute(tc.i)
+			if (err != nil) != tc.err {
+				t.Fatal(err)
+			}
+			if a != nil && !bytes.Equal([]byte(tc.e), a.Output) {
+				t.Errorf("\nexp: %#v\nact: %#v", tc.e, string(a.Output))
+			}
+		})
+	}
+}

--- a/tfunc/tfunc.go
+++ b/tfunc/tfunc.go
@@ -1,0 +1,82 @@
+package tfunc
+
+import (
+	"os"
+	"text/template"
+)
+
+func All() template.FuncMap {
+	all := make(template.FuncMap)
+	allfuncs := []func() template.FuncMap{ConsulFilters, Env, Control, Helpers}
+	for _, f := range allfuncs {
+		for k, v := range f() {
+			all[k] = v
+		}
+	}
+	return all
+}
+
+func Env() template.FuncMap {
+	return template.FuncMap{
+		"env": envFunc(os.Environ()),
+	}
+}
+
+func ConsulFilters() template.FuncMap {
+	return template.FuncMap{
+		"byKey":  byKey,
+		"byTag":  byTag,
+		"byMeta": byMeta,
+	}
+}
+
+func Control() template.FuncMap {
+	return template.FuncMap{
+		"contains":       contains,
+		"containsAll":    containsSomeFunc(true, true),
+		"containsAny":    containsSomeFunc(false, false),
+		"containsNone":   containsSomeFunc(true, false),
+		"containsNotAll": containsSomeFunc(false, true),
+		"in":             in,
+		"loop":           loop,
+	}
+}
+
+func Helpers() template.FuncMap {
+	return template.FuncMap{
+		// Parsing
+		"parseBool":  parseBool,
+		"parseFloat": parseFloat,
+		"parseInt":   parseInt,
+		"parseJSON":  parseJSON,
+		"parseUint":  parseUint,
+		"parseYAML":  parseYAML,
+		// ToSomething
+		"toLower":      toLower,
+		"toUpper":      toUpper,
+		"toTitle":      toTitle,
+		"toJSON":       toJSON,
+		"toJSONPretty": toJSONPretty,
+		"toTOML":       toTOML,
+		"toYAML":       toYAML,
+		// (D)Encoding
+		"base64Decode":    base64Decode,
+		"base64Encode":    base64Encode,
+		"base64URLDecode": base64URLDecode,
+		"base64URLEncode": base64URLEncode,
+		"sha256Hex":       sha256Hex,
+		// String
+		"join":            join,
+		"split":           split,
+		"trimSpace":       trimSpace,
+		"indent":          indent,
+		"replaceAll":      replaceAll,
+		"regexReplaceAll": regexReplaceAll,
+		"regexMatch":      regexMatch,
+		// Other
+		"explode":    explode,
+		"explodeMap": explodeMap,
+		"timestamp":  timestamp,
+		"sockaddr":   sockaddr,
+	}
+}

--- a/tfunc/tfunc_test.go
+++ b/tfunc/tfunc_test.go
@@ -1,0 +1,36 @@
+package tfunc
+
+import (
+	"fmt"
+	"testing"
+	"text/template"
+
+	"github.com/hashicorp/hcat"
+)
+
+func testHealthServiceQueryID(service string) string {
+	return fmt.Sprintf("health.service(%s|passing)", service)
+}
+
+func testKVListQueryID(prefix string) string {
+	return fmt.Sprintf("kv.list(%s)", prefix)
+}
+
+func TestAllForDups(t *testing.T) {
+	all := make(template.FuncMap)
+	allfuncs := []func() template.FuncMap{ConsulFilters, Env, Control, Helpers}
+	for _, f := range allfuncs {
+		for k, v := range f() {
+			if _, ok := all[k]; ok {
+				t.Fatal("duplicate entry")
+			}
+			all[k] = v
+		}
+	}
+}
+
+// Wrap the new template to use our template library
+func NewTemplate(ti hcat.TemplateInput) *hcat.Template {
+	ti.FuncMapMerge = All()
+	return hcat.NewTemplate(ti)
+}

--- a/tfunc/time.go
+++ b/tfunc/time.go
@@ -1,0 +1,28 @@
+package tfunc
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+)
+
+// now is function that represents the current time in UTC. This is here
+// primarily for the tests to override times.
+var now = func() time.Time { return time.Now().UTC() }
+
+// timestamp returns the current UNIX timestamp in UTC. If an argument is
+// specified, it will be used to format the timestamp.
+func timestamp(s ...string) (string, error) {
+	switch len(s) {
+	case 0:
+		return now().Format(time.RFC3339), nil
+	case 1:
+		if s[0] == "unix" {
+			return strconv.FormatInt(now().Unix(), 10), nil
+		}
+		return now().Format(s[0]), nil
+	default:
+		return "", fmt.Errorf("timestamp: wrong number of arguments, "+
+			"expected 0 or 1, but got %d", len(s))
+	}
+}

--- a/tfunc/time_test.go
+++ b/tfunc/time_test.go
@@ -1,0 +1,58 @@
+package tfunc
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/hcat"
+)
+
+func TestTimeExecute(t *testing.T) {
+	t.Parallel()
+
+	// overwrite now variable from ./time.go
+	now = func() time.Time { return time.Unix(0, 0).UTC() }
+
+	cases := []struct {
+		name string
+		ti   hcat.TemplateInput
+		i    hcat.Recaller
+		e    string
+		err  bool
+	}{
+		{
+			"timestamp",
+			hcat.TemplateInput{
+				Contents: `{{ timestamp }}`,
+			},
+			hcat.NewStore(),
+			"1970-01-01T00:00:00Z",
+			false,
+		},
+		{
+			"helper_timestamp__formatted",
+			hcat.TemplateInput{
+				Contents: `{{ timestamp "2006-01-02" }}`,
+			},
+			hcat.NewStore(),
+			"1970-01-01",
+			false,
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
+			tpl := NewTemplate(tc.ti)
+
+			a, err := tpl.Execute(tc.i)
+			if (err != nil) != tc.err {
+				t.Fatal(err)
+			}
+			if a != nil && !bytes.Equal([]byte(tc.e), a.Output) {
+				t.Errorf("\nexp: %#v\nact: %#v", tc.e, string(a.Output))
+			}
+		})
+	}
+}

--- a/tfunc/transform.go
+++ b/tfunc/transform.go
@@ -1,0 +1,109 @@
+package tfunc
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"io/ioutil"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+	"github.com/pkg/errors"
+	yaml "gopkg.in/yaml.v2"
+)
+
+// base64Decode decodes the given string as a base64 string, returning an error
+// if it fails.
+func base64Decode(s string) (string, error) {
+	v, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		return "", errors.Wrap(err, "base64Decode")
+	}
+	return string(v), nil
+}
+
+// base64Encode encodes the given value into a string represented as base64.
+func base64Encode(s string) (string, error) {
+	return base64.StdEncoding.EncodeToString([]byte(s)), nil
+}
+
+// base64URLDecode decodes the given string as a URL-safe base64 string.
+func base64URLDecode(s string) (string, error) {
+	v, err := base64.URLEncoding.DecodeString(s)
+	if err != nil {
+		return "", errors.Wrap(err, "base64URLDecode")
+	}
+	return string(v), nil
+}
+
+// base64URLEncode encodes the given string to be URL-safe.
+func base64URLEncode(s string) (string, error) {
+	return base64.URLEncoding.EncodeToString([]byte(s)), nil
+}
+
+// sha256Hex return the sha256 hex of a string
+func sha256Hex(item string) (string, error) {
+	h := sha256.New()
+	h.Write([]byte(item))
+	output := hex.EncodeToString(h.Sum(nil))
+	return output, nil
+}
+
+// toLower converts the given string (usually by a pipe) to lowercase.
+func toLower(s string) (string, error) {
+	return strings.ToLower(s), nil
+}
+
+// toJSON converts the given structure into a deeply nested JSON string.
+func toJSON(i interface{}) (string, error) {
+	result, err := json.Marshal(i)
+	if err != nil {
+		return "", errors.Wrap(err, "toJSON")
+	}
+	return string(bytes.TrimSpace(result)), err
+}
+
+// toTitle converts the given string (usually by a pipe) to titlecase.
+func toTitle(s string) (string, error) {
+	return strings.Title(s), nil
+}
+
+// toUpper converts the given string (usually by a pipe) to uppercase.
+func toUpper(s string) (string, error) {
+	return strings.ToUpper(s), nil
+}
+
+// toJSONPretty converts the given structure into a deeply nested pretty JSON
+// string.
+func toJSONPretty(m map[string]interface{}) (string, error) {
+	result, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return "", errors.Wrap(err, "toJSONPretty")
+	}
+	return string(bytes.TrimSpace(result)), err
+}
+
+// toYAML converts the given structure into a deeply nested YAML string.
+func toYAML(m map[string]interface{}) (string, error) {
+	result, err := yaml.Marshal(m)
+	if err != nil {
+		return "", errors.Wrap(err, "toYAML")
+	}
+	return string(bytes.TrimSpace(result)), nil
+}
+
+// toTOML converts the given structure into a deeply nested TOML string.
+func toTOML(m map[string]interface{}) (string, error) {
+	buf := bytes.NewBuffer([]byte{})
+	enc := toml.NewEncoder(buf)
+	if err := enc.Encode(m); err != nil {
+		return "", errors.Wrap(err, "toTOML")
+	}
+	result, err := ioutil.ReadAll(buf)
+	if err != nil {
+		return "", errors.Wrap(err, "toTOML")
+	}
+	return string(bytes.TrimSpace(result)), nil
+}

--- a/tfunc/transform_test.go
+++ b/tfunc/transform_test.go
@@ -1,0 +1,144 @@
+package tfunc
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/hcat"
+)
+
+func TestTransformExecute(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		ti   hcat.TemplateInput
+		i    hcat.Recaller
+		e    string
+		err  bool
+	}{
+		{
+			"func_base64Decode",
+			hcat.TemplateInput{
+				Contents: `{{ base64Decode "aGVsbG8=" }}`,
+			},
+			nil,
+			"hello",
+			false,
+		},
+		{
+			"func_base64Decode_bad",
+			hcat.TemplateInput{
+				Contents: `{{ base64Decode "aGVsxxbG8=" }}`,
+			},
+			nil,
+			"",
+			true,
+		},
+		{
+			"func_base64Encode",
+			hcat.TemplateInput{
+				Contents: `{{ base64Encode "hello" }}`,
+			},
+			nil,
+			"aGVsbG8=",
+			false,
+		},
+		{
+			"func_base64URLDecode",
+			hcat.TemplateInput{
+				Contents: `{{ base64URLDecode "dGVzdGluZzEyMw==" }}`,
+			},
+			nil,
+			"testing123",
+			false,
+		},
+		{
+			"func_base64URLDecode_bad",
+			hcat.TemplateInput{
+				Contents: `{{ base64URLDecode "aGVsxxbG8=" }}`,
+			},
+			nil,
+			"",
+			true,
+		},
+		{
+			"func_base64URLEncode",
+			hcat.TemplateInput{
+				Contents: `{{ base64URLEncode "testing123" }}`,
+			},
+			nil,
+			"dGVzdGluZzEyMw==",
+			false,
+		},
+		{
+			"helper_toJSON",
+			hcat.TemplateInput{
+				Contents: `{{ "a,b,c" | split "," | toJSON }}`,
+			},
+			hcat.NewStore(),
+			"[\"a\",\"b\",\"c\"]",
+			false,
+		},
+		{
+			"helper_toLower",
+			hcat.TemplateInput{
+				Contents: `{{ "HI" | toLower }}`,
+			},
+			hcat.NewStore(),
+			"hi",
+			false,
+		},
+		{
+			"helper_toTitle",
+			hcat.TemplateInput{
+				Contents: `{{ "this is a sentence" | toTitle }}`,
+			},
+			hcat.NewStore(),
+			"This Is A Sentence",
+			false,
+		},
+		{
+			"helper_toTOML",
+			hcat.TemplateInput{
+				Contents: `{{ "{\"foo\":\"bar\"}" | parseJSON | toTOML }}`,
+			},
+			hcat.NewStore(),
+			"foo = \"bar\"",
+			false,
+		},
+		{
+			"helper_toUpper",
+			hcat.TemplateInput{
+				Contents: `{{ "hi" | toUpper }}`,
+			},
+			hcat.NewStore(),
+			"HI",
+			false,
+		},
+		{
+			"helper_toYAML",
+			hcat.TemplateInput{
+				Contents: `{{ "{\"foo\":\"bar\"}" | parseJSON | toYAML }}`,
+			},
+			hcat.NewStore(),
+			"foo: bar",
+			false,
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
+			tpl := hcat.NewTemplate(tc.ti)
+
+			a, err := tpl.Execute(tc.i)
+			if (err != nil) != tc.err {
+				t.Fatal(err)
+			}
+			if a != nil && !bytes.Equal([]byte(tc.e), a.Output) {
+				t.Errorf("\nexp: %#v\nact: %#v", tc.e, string(a.Output))
+			}
+		})
+	}
+}


### PR DESCRIPTION
Move all(1) the non-dependency/external template functions out of the
core library and into a sub-module. Include ways to import all of them
or a subset of them as template.FuncMap entries.

(1) but a few that are overly specific to consul-template

This only adds the submodule, it doesn't remove them from the core. That will come in a followup once this is merged.

Fixes #19