### PR TITLE
remove old/redundant data received map

### DIFF
--- a/store_test.go
+++ b/store_test.go
@@ -15,10 +15,6 @@ func TestNewStore(t *testing.T) {
 	if st.data == nil {
 		t.Errorf("expected data to not be nil")
 	}
-
-	if st.receivedData == nil {
-		t.Errorf("expected receivedData to not be nil")
-	}
 }
 
 func TestRecall(t *testing.T) {


### PR DESCRIPTION
This map was added back (in consul-template) when they used a different
internal map for each data type and it was expensive and ugly to check
them all every time, so they introduced this field to simplify checking.
Later they converted to a single map[string]interface{} to hold all the
data but didn't remove the (now redundant) map that tracked received.