### PR TITLE
New dependency tracking

### DIFF
--- a/resolver.go
+++ b/resolver.go
@@ -35,7 +35,7 @@ type Watcherer interface {
 // Templater the interface the Template provides.
 // The interface is used to make the used/required API explicit.
 type Templater interface {
-	Execute(Watcherer) (*ExecuteResult, error)
+	Execute(Watcherer) ([]byte, error)
 	ID() string
 }
 
@@ -53,7 +53,7 @@ func (r *Resolver) Run(tmpl Templater, w Watcherer) (ResolveEvent, error) {
 	// Attempt to render the template, returning any missing dependencies and
 	// the rendered contents. If there are any missing dependencies, the
 	// contents cannot be rendered or trusted!
-	result, err := tmpl.Execute(w)
+	output, err := tmpl.Execute(w)
 	switch err {
 	case nil:
 	case ErrMissingValues:
@@ -64,5 +64,5 @@ func (r *Resolver) Run(tmpl Templater, w Watcherer) (ResolveEvent, error) {
 		return ResolveEvent{}, err
 	}
 
-	return ResolveEvent{Complete: true, Contents: result.Output}, nil
+	return ResolveEvent{Complete: true, Contents: output}, nil
 }

--- a/resolver.go
+++ b/resolver.go
@@ -1,7 +1,5 @@
 package hcat
 
-import "github.com/hashicorp/hcat/dep"
-
 // Resolver is responsible rendering Templates and invoking Commands.
 // Empty but reserving the space for future use.
 type Resolver struct{}
@@ -29,17 +27,15 @@ func NewResolver() *Resolver {
 // Watcherer is the subset of the Watcher's API that the resolver needs.
 // The interface is used to make the used/required API explicit.
 type Watcherer interface {
-	Recaller
-	Add(dep.Dependency) bool
-	Changed(tmplID string) bool
 	Buffer(tmplID string) bool
-	Register(tmplID string, deps ...dep.Dependency)
+	Recaller(*Template) Recaller
+	Complete(Notifier) bool
 }
 
 // Templater the interface the Template provides.
 // The interface is used to make the used/required API explicit.
 type Templater interface {
-	Execute(Recaller) (*ExecuteResult, error)
+	Execute(Watcherer) (*ExecuteResult, error)
 	ID() string
 }
 
@@ -47,12 +43,9 @@ type Templater interface {
 // output returns Complete as true. It uses the watcher for dependency
 // lookup state. The content will be updated each pass until complete.
 func (r *Resolver) Run(tmpl Templater, w Watcherer) (ResolveEvent, error) {
+
 	// Check if this dependency has any dependencies that have been change and
 	// if not, don't waste time re-rendering it.
-	if !w.Changed(tmpl.ID()) {
-		return ResolveEvent{}, nil
-	}
-
 	if w.Buffer(tmpl.ID()) {
 		return ResolveEvent{Complete: false}, nil
 	}
@@ -61,23 +54,14 @@ func (r *Resolver) Run(tmpl Templater, w Watcherer) (ResolveEvent, error) {
 	// the rendered contents. If there are any missing dependencies, the
 	// contents cannot be rendered or trusted!
 	result, err := tmpl.Execute(w)
-	if err != nil {
-		return ResolveEvent{}, err
-	}
-
-	// register all dependencies used
-	if l := result.Used.Len(); l > 0 {
-		w.Register(tmpl.ID(), result.Used.List()...)
-	}
-
-	// add missing dependencies to watcher
-	if l := result.Missing.Len(); l > 0 {
-		for _, d := range result.Missing.List() {
-			w.Add(d)
-		}
-		// If the template is missing data for some dependencies then we are
-		// not ready to render and need to move on to the next one.
+	switch err {
+	case nil:
+	case ErrMissingValues:
 		return ResolveEvent{missing: true}, nil
+	case ErrNoNewValues:
+		return ResolveEvent{}, nil
+	default:
+		return ResolveEvent{}, err
 	}
 
 	return ResolveEvent{Complete: true, Contents: result.Output}, nil

--- a/store_test.go
+++ b/store_test.go
@@ -15,10 +15,6 @@ func TestNewStore(t *testing.T) {
 	if st.data == nil {
 		t.Errorf("expected data to not be nil")
 	}
-
-	if st.receivedData == nil {
-		t.Errorf("expected receivedData to not be nil")
-	}
 }
 
 func TestRecall(t *testing.T) {

--- a/template.go
+++ b/template.go
@@ -146,14 +146,8 @@ func (t *Template) Render(content []byte) (RenderResult, error) {
 	return t.renderer.Render(content)
 }
 
-// ExecuteResult is the result of the template execution.
-type ExecuteResult struct {
-	// Output the (possibly partially) filled in template
-	Output []byte
-}
-
 // Execute evaluates this template in the provided context.
-func (t *Template) Execute(w Watcherer) (*ExecuteResult, error) {
+func (t *Template) Execute(w Watcherer) ([]byte, error) {
 	if !t.isDirty() {
 		return nil, ErrNoNewValues
 	}
@@ -188,9 +182,7 @@ func (t *Template) Execute(w Watcherer) (*ExecuteResult, error) {
 		return nil, ErrMissingValues
 	}
 
-	return &ExecuteResult{
-		Output: b.Bytes(),
-	}, nil
+	return b.Bytes(), nil
 }
 
 // funcMapInput is input to the funcMap, which builds the template functions.

--- a/template.go
+++ b/template.go
@@ -12,8 +12,8 @@ import (
 
 // ErrMissingValues is the error returned when a template doesn't completely
 // render due to missing values (values that haven't been fetched yet).
-var ErrMissingValues = errors.New("Missing template values")
-var ErrNoNewValues = errors.New("No new values for template")
+var ErrMissingValues = errors.New("missing template values")
+var ErrNoNewValues = errors.New("no new values for template")
 
 // Template is the internal representation of an individual template to process.
 // The template retains the relationship between it's contents and is

--- a/template.go
+++ b/template.go
@@ -177,7 +177,7 @@ func (t *Template) Execute(w Watcherer) ([]byte, error) {
 	}
 
 	// Checks if all values in use have been fetched.
-	// ..also cleans out data no longer used by this template.
+	// Also cleans out data no longer used by this template.
 	if !w.Complete(t) {
 		return nil, ErrMissingValues
 	}

--- a/template_test.go
+++ b/template_test.go
@@ -658,8 +658,8 @@ func TestTemplate_Execute(t *testing.T) {
 			if (err != nil) != tc.err {
 				t.Fatal(err)
 			}
-			if a != nil && !bytes.Equal([]byte(tc.e), a.Output) {
-				t.Errorf("\nexp: %#v\nact: %#v", tc.e, string(a.Output))
+			if !bytes.Equal([]byte(tc.e), a) {
+				t.Errorf("\nexp: %#v\nact: %#v", tc.e, string(a))
 			}
 		})
 	}

--- a/template_test.go
+++ b/template_test.go
@@ -68,6 +68,7 @@ func TestNewTemplate(t *testing.T) {
 	for i, tc := range cases {
 		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
 			tmpl := NewTemplate(tc.i)
+			tc.e.dirty, tmpl.dirty = nil, nil // don't compare well
 			if !reflect.DeepEqual(tc.e, tmpl) {
 				t.Errorf("\nexp: %#v\nact: %#v", tc.e, tmpl)
 			}
@@ -95,7 +96,7 @@ func TestTemplate_Execute(t *testing.T) {
 	cases := []struct {
 		name string
 		ti   TemplateInput
-		i    Recaller
+		i    *Store
 		e    string
 		err  bool
 	}{
@@ -652,7 +653,8 @@ func TestTemplate_Execute(t *testing.T) {
 		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
 			tpl := NewTemplate(tc.ti)
 
-			a, err := tpl.Execute(tc.i)
+			w := fakeWatcher{tc.i}
+			a, err := tpl.Execute(w)
 			if (err != nil) != tc.err {
 				t.Fatal(err)
 			}
@@ -660,5 +662,17 @@ func TestTemplate_Execute(t *testing.T) {
 				t.Errorf("\nexp: %#v\nact: %#v", tc.e, string(a.Output))
 			}
 		})
+	}
+}
+
+type fakeWatcher struct {
+	*Store
+}
+
+func (fakeWatcher) Buffer(string) bool       { return false }
+func (f fakeWatcher) Complete(Notifier) bool { return true }
+func (f fakeWatcher) Recaller(t *Template) Recaller {
+	return func(d dep.Dependency) (value interface{}, found bool) {
+		return f.Store.Recall(d.String())
 	}
 }

--- a/tfunc/consul_test.go
+++ b/tfunc/consul_test.go
@@ -189,8 +189,8 @@ func TestConsulExecute(t *testing.T) {
 			if (err != nil) != tc.err {
 				t.Fatal(err)
 			}
-			if a != nil && !bytes.Equal([]byte(tc.e), a.Output) {
-				t.Errorf("\nexp: %#v\nact: %#v", tc.e, string(a.Output))
+			if !bytes.Equal([]byte(tc.e), a) {
+				t.Errorf("\nexp: %#v\nact: %#v", tc.e, string(a))
 			}
 		})
 	}

--- a/tfunc/contains_test.go
+++ b/tfunc/contains_test.go
@@ -236,8 +236,8 @@ func TestContainsExecute(t *testing.T) {
 			if (err != nil) != tc.err {
 				t.Fatal(err)
 			}
-			if a != nil && !bytes.Equal([]byte(tc.e), a.Output) {
-				t.Errorf("\nexp: %#v\nact: %#v", tc.e, string(a.Output))
+			if !bytes.Equal([]byte(tc.e), a) {
+				t.Errorf("\nexp: %#v\nact: %#v", tc.e, string(a))
 			}
 		})
 	}

--- a/tfunc/env_test.go
+++ b/tfunc/env_test.go
@@ -21,7 +21,7 @@ func TestEnvExecute(t *testing.T) {
 	cases := []struct {
 		name string
 		ti   hcat.TemplateInput
-		i    hcat.Recaller
+		i    hcat.Watcherer
 		e    string
 		err  bool
 	}{
@@ -31,7 +31,7 @@ func TestEnvExecute(t *testing.T) {
 				// CT_TEST set above
 				Contents: `{{ env "CT_TEST" }}`,
 			},
-			hcat.NewStore(),
+			fakeWatcher{hcat.NewStore()},
 			"1",
 			false,
 		},

--- a/tfunc/env_test.go
+++ b/tfunc/env_test.go
@@ -45,8 +45,8 @@ func TestEnvExecute(t *testing.T) {
 			if (err != nil) != tc.err {
 				t.Fatal(err)
 			}
-			if a != nil && !bytes.Equal([]byte(tc.e), a.Output) {
-				t.Errorf("\nexp: %#v\nact: %#v", tc.e, string(a.Output))
+			if !bytes.Equal([]byte(tc.e), a) {
+				t.Errorf("\nexp: %#v\nact: %#v", tc.e, string(a))
 			}
 		})
 	}

--- a/tfunc/explode_test.go
+++ b/tfunc/explode_test.go
@@ -65,8 +65,8 @@ func TestExplodeExecute(t *testing.T) {
 			if (err != nil) != tc.err {
 				t.Fatal(err)
 			}
-			if a != nil && !bytes.Equal([]byte(tc.e), a.Output) {
-				t.Errorf("\nexp: %#v\nact: %#v", tc.e, string(a.Output))
+			if !bytes.Equal([]byte(tc.e), a) {
+				t.Errorf("\nexp: %#v\nact: %#v", tc.e, string(a))
 			}
 		})
 	}

--- a/tfunc/explode_test.go
+++ b/tfunc/explode_test.go
@@ -15,7 +15,7 @@ func TestExplodeExecute(t *testing.T) {
 	cases := []struct {
 		name string
 		ti   hcat.TemplateInput
-		i    hcat.Recaller
+		i    hcat.Watcherer
 		e    string
 		err  bool
 	}{
@@ -24,7 +24,7 @@ func TestExplodeExecute(t *testing.T) {
 			hcat.TemplateInput{
 				Contents: `{{ range $k, $v := tree "list" | explode }}{{ $k }}{{ $v }}{{ end }}`,
 			},
-			func() *hcat.Store {
+			func() hcat.Watcherer {
 				st := hcat.NewStore()
 				id := testKVListQueryID("list")
 				st.Save(id, []*dep.KeyPair{
@@ -32,7 +32,7 @@ func TestExplodeExecute(t *testing.T) {
 					{Key: "foo/bar", Value: "a"},
 					{Key: "zip/zap", Value: "b"},
 				})
-				return st
+				return fakeWatcher{st}
 			}(),
 			"foomap[bar:a]zipmap[zap:b]",
 			false,
@@ -51,7 +51,7 @@ func TestExplodeExecute(t *testing.T) {
 					},
 				},
 			},
-			hcat.NewStore(),
+			fakeWatcher{hcat.NewStore()},
 			"map[foo:map[bar:a] qux:c zip:map[zap:d]]",
 			false,
 		},

--- a/tfunc/loop_test.go
+++ b/tfunc/loop_test.go
@@ -84,8 +84,8 @@ func TestLoopExecute(t *testing.T) {
 			if (err != nil) != tc.err {
 				t.Fatal(err)
 			}
-			if a != nil && !bytes.Equal([]byte(tc.e), a.Output) {
-				t.Errorf("\nexp: %#v\nact: %#v", tc.e, string(a.Output))
+			if !bytes.Equal([]byte(tc.e), a) {
+				t.Errorf("\nexp: %#v\nact: %#v", tc.e, string(a))
 			}
 		})
 	}

--- a/tfunc/loop_test.go
+++ b/tfunc/loop_test.go
@@ -14,7 +14,7 @@ func TestLoopExecute(t *testing.T) {
 	cases := []struct {
 		name string
 		ti   hcat.TemplateInput
-		i    hcat.Recaller
+		i    hcat.Watcherer
 		e    string
 		err  bool
 	}{
@@ -23,7 +23,7 @@ func TestLoopExecute(t *testing.T) {
 			hcat.TemplateInput{
 				Contents: `{{ range loop 3 }}1{{ end }}`,
 			},
-			hcat.NewStore(),
+			fakeWatcher{hcat.NewStore()},
 			"111",
 			false,
 		},
@@ -32,7 +32,7 @@ func TestLoopExecute(t *testing.T) {
 			hcat.TemplateInput{
 				Contents: `{{ range $i := loop 3 }}{{ $i }}{{ end }}`,
 			},
-			hcat.NewStore(),
+			fakeWatcher{hcat.NewStore()},
 			"012",
 			false,
 		},
@@ -41,7 +41,7 @@ func TestLoopExecute(t *testing.T) {
 			hcat.TemplateInput{
 				Contents: `{{ range loop 1 3 }}1{{ end }}`,
 			},
-			hcat.NewStore(),
+			fakeWatcher{hcat.NewStore()},
 			"11",
 			false,
 		},
@@ -50,7 +50,7 @@ func TestLoopExecute(t *testing.T) {
 			hcat.TemplateInput{
 				Contents: `{{ range loop 1 "3" }}1{{ end }}`,
 			},
-			hcat.NewStore(),
+			fakeWatcher{hcat.NewStore()},
 			"11",
 			false,
 		},
@@ -59,7 +59,7 @@ func TestLoopExecute(t *testing.T) {
 			hcat.TemplateInput{
 				Contents: `{{ $i := print "3" | parseInt }}{{ range loop 1 $i }}1{{ end }}`,
 			},
-			hcat.NewStore(),
+			fakeWatcher{hcat.NewStore()},
 			"11",
 			false,
 		},
@@ -70,7 +70,7 @@ func TestLoopExecute(t *testing.T) {
 				Contents: `{{$n := 3 }}` +
 					`{{ range $i := loop $n }}{{ $i }}{{ end }}`,
 			},
-			hcat.NewStore(),
+			fakeWatcher{hcat.NewStore()},
 			"012",
 			false,
 		},

--- a/tfunc/math_test.go
+++ b/tfunc/math_test.go
@@ -14,7 +14,7 @@ func TestMathExecute(t *testing.T) {
 	cases := []struct {
 		name string
 		ti   hcat.TemplateInput
-		i    hcat.Recaller
+		i    hcat.Watcherer
 		e    string
 		err  bool
 	}{
@@ -23,7 +23,7 @@ func TestMathExecute(t *testing.T) {
 			hcat.TemplateInput{
 				Contents: `{{ 2 | add 2 }}`,
 			},
-			hcat.NewStore(),
+			fakeWatcher{hcat.NewStore()},
 			"4",
 			false,
 		},
@@ -32,7 +32,7 @@ func TestMathExecute(t *testing.T) {
 			hcat.TemplateInput{
 				Contents: `{{ 2 | subtract 2 }}`,
 			},
-			hcat.NewStore(),
+			fakeWatcher{hcat.NewStore()},
 			"0",
 			false,
 		},
@@ -41,7 +41,7 @@ func TestMathExecute(t *testing.T) {
 			hcat.TemplateInput{
 				Contents: `{{ 2 | multiply 2 }}`,
 			},
-			hcat.NewStore(),
+			fakeWatcher{hcat.NewStore()},
 			"4",
 			false,
 		},
@@ -50,7 +50,7 @@ func TestMathExecute(t *testing.T) {
 			hcat.TemplateInput{
 				Contents: `{{ 2 | divide 2 }}`,
 			},
-			hcat.NewStore(),
+			fakeWatcher{hcat.NewStore()},
 			"1",
 			false,
 		},
@@ -59,7 +59,7 @@ func TestMathExecute(t *testing.T) {
 			hcat.TemplateInput{
 				Contents: `{{ 3 | modulo 2 }}`,
 			},
-			hcat.NewStore(),
+			fakeWatcher{hcat.NewStore()},
 			"1",
 			false,
 		},
@@ -68,7 +68,7 @@ func TestMathExecute(t *testing.T) {
 			hcat.TemplateInput{
 				Contents: `{{ 3 | minimum 2 }}`,
 			},
-			hcat.NewStore(),
+			fakeWatcher{hcat.NewStore()},
 			"2",
 			false,
 		},
@@ -77,7 +77,7 @@ func TestMathExecute(t *testing.T) {
 			hcat.TemplateInput{
 				Contents: `{{ 3 | maximum 2 }}`,
 			},
-			hcat.NewStore(),
+			fakeWatcher{hcat.NewStore()},
 			"3",
 			false,
 		},

--- a/tfunc/math_test.go
+++ b/tfunc/math_test.go
@@ -91,8 +91,8 @@ func TestMathExecute(t *testing.T) {
 			if (err != nil) != tc.err {
 				t.Fatal(err)
 			}
-			if a != nil && !bytes.Equal([]byte(tc.e), a.Output) {
-				t.Errorf("\nexp: %#v\nact: %#v", tc.e, string(a.Output))
+			if !bytes.Equal([]byte(tc.e), a) {
+				t.Errorf("\nexp: %#v\nact: %#v", tc.e, string(a))
 			}
 		})
 	}

--- a/tfunc/parse_test.go
+++ b/tfunc/parse_test.go
@@ -100,8 +100,8 @@ func TestParseExecute(t *testing.T) {
 			if (err != nil) != tc.err {
 				t.Fatal(err)
 			}
-			if a != nil && !bytes.Equal([]byte(tc.e), a.Output) {
-				t.Errorf("\nexp: %#v\nact: %#v", tc.e, string(a.Output))
+			if !bytes.Equal([]byte(tc.e), a) {
+				t.Errorf("\nexp: %#v\nact: %#v", tc.e, string(a))
 			}
 		})
 	}

--- a/tfunc/parse_test.go
+++ b/tfunc/parse_test.go
@@ -14,7 +14,7 @@ func TestParseExecute(t *testing.T) {
 	cases := []struct {
 		name string
 		ti   hcat.TemplateInput
-		i    hcat.Recaller
+		i    hcat.Watcherer
 		e    string
 		err  bool
 	}{
@@ -23,7 +23,7 @@ func TestParseExecute(t *testing.T) {
 			hcat.TemplateInput{
 				Contents: `{{ "true" | parseBool }}`,
 			},
-			hcat.NewStore(),
+			fakeWatcher{hcat.NewStore()},
 			"true",
 			false,
 		},
@@ -32,7 +32,7 @@ func TestParseExecute(t *testing.T) {
 			hcat.TemplateInput{
 				Contents: `{{ "1.2" | parseFloat }}`,
 			},
-			hcat.NewStore(),
+			fakeWatcher{hcat.NewStore()},
 			"1.2",
 			false,
 		},
@@ -41,7 +41,7 @@ func TestParseExecute(t *testing.T) {
 			hcat.TemplateInput{
 				Contents: `{{ "-1" | parseInt }}`,
 			},
-			hcat.NewStore(),
+			fakeWatcher{hcat.NewStore()},
 			"-1",
 			false,
 		},
@@ -50,7 +50,7 @@ func TestParseExecute(t *testing.T) {
 			hcat.TemplateInput{
 				Contents: `{{ "{\"foo\": \"bar\"}" | parseJSON }}`,
 			},
-			hcat.NewStore(),
+			fakeWatcher{hcat.NewStore()},
 			"map[foo:bar]",
 			false,
 		},
@@ -59,7 +59,7 @@ func TestParseExecute(t *testing.T) {
 			hcat.TemplateInput{
 				Contents: `{{ "1" | parseUint }}`,
 			},
-			hcat.NewStore(),
+			fakeWatcher{hcat.NewStore()},
 			"1",
 			false,
 		},
@@ -68,7 +68,7 @@ func TestParseExecute(t *testing.T) {
 			hcat.TemplateInput{
 				Contents: `{{ "foo: bar" | parseYAML }}`,
 			},
-			hcat.NewStore(),
+			fakeWatcher{hcat.NewStore()},
 			"map[foo:bar]",
 			false,
 		},
@@ -77,7 +77,7 @@ func TestParseExecute(t *testing.T) {
 			hcat.TemplateInput{
 				Contents: `{{ "foo: bar\nbaz: \"foo\"" | parseYAML }}`,
 			},
-			hcat.NewStore(),
+			fakeWatcher{hcat.NewStore()},
 			"map[baz:foo foo:bar]",
 			false,
 		},
@@ -86,7 +86,7 @@ func TestParseExecute(t *testing.T) {
 			hcat.TemplateInput{
 				Contents: `{{ "foo:\n  bar: \"baz\"\n  baz: 7" | parseYAML }}`,
 			},
-			hcat.NewStore(),
+			fakeWatcher{hcat.NewStore()},
 			"map[foo:map[bar:baz baz:7]]",
 			false,
 		},

--- a/tfunc/sockaddr_test.go
+++ b/tfunc/sockaddr_test.go
@@ -14,7 +14,7 @@ func TestSockAddrExecute(t *testing.T) {
 	cases := []struct {
 		name string
 		ti   hcat.TemplateInput
-		i    hcat.Recaller
+		i    hcat.Watcherer
 		e    string
 		err  bool
 	}{}

--- a/tfunc/sockaddr_test.go
+++ b/tfunc/sockaddr_test.go
@@ -27,8 +27,8 @@ func TestSockAddrExecute(t *testing.T) {
 			if (err != nil) != tc.err {
 				t.Fatal(err)
 			}
-			if a != nil && !bytes.Equal([]byte(tc.e), a.Output) {
-				t.Errorf("\nexp: %#v\nact: %#v", tc.e, string(a.Output))
+			if !bytes.Equal([]byte(tc.e), a) {
+				t.Errorf("\nexp: %#v\nact: %#v", tc.e, string(a))
 			}
 		})
 	}

--- a/tfunc/string_test.go
+++ b/tfunc/string_test.go
@@ -14,7 +14,7 @@ func TestStringExecute(t *testing.T) {
 	cases := []struct {
 		name string
 		ti   hcat.TemplateInput
-		i    hcat.Recaller
+		i    hcat.Watcherer
 		e    string
 		err  bool
 	}{
@@ -23,7 +23,7 @@ func TestStringExecute(t *testing.T) {
 			hcat.TemplateInput{
 				Contents: `{{ "hello\nhello\r\nHELLO\r\nhello\nHELLO" | indent 4 }}`,
 			},
-			hcat.NewStore(),
+			fakeWatcher{hcat.NewStore()},
 			"    hello\n    hello\r\n    HELLO\r\n    hello\n    HELLO",
 			false,
 		},
@@ -32,7 +32,7 @@ func TestStringExecute(t *testing.T) {
 			hcat.TemplateInput{
 				Contents: `{{ "hello\nhello\r\nHELLO\r\nhello\nHELLO" | indent -4 }}`,
 			},
-			hcat.NewStore(),
+			fakeWatcher{hcat.NewStore()},
 			"    hello\n    hello\r\n    HELLO\r\n    hello\n    HELLO",
 			true,
 		},
@@ -41,7 +41,7 @@ func TestStringExecute(t *testing.T) {
 			hcat.TemplateInput{
 				Contents: `{{ "hello\nhello\r\nHELLO\r\nhello\nHELLO" | indent 0 }}`,
 			},
-			hcat.NewStore(),
+			fakeWatcher{hcat.NewStore()},
 			"hello\nhello\r\nHELLO\r\nhello\nHELLO",
 			false,
 		},
@@ -50,7 +50,7 @@ func TestStringExecute(t *testing.T) {
 			hcat.TemplateInput{
 				Contents: `{{ "a,b,c" | split "," | join ";" }}`,
 			},
-			hcat.NewStore(),
+			fakeWatcher{hcat.NewStore()},
 			"a;b;c",
 			false,
 		},
@@ -59,7 +59,7 @@ func TestStringExecute(t *testing.T) {
 			hcat.TemplateInput{
 				Contents: `{{ "\t hi\n " | trimSpace }}`,
 			},
-			hcat.NewStore(),
+			fakeWatcher{hcat.NewStore()},
 			"hi",
 			false,
 		},
@@ -68,7 +68,7 @@ func TestStringExecute(t *testing.T) {
 			hcat.TemplateInput{
 				Contents: `{{ "a,b,c" | split "," }}`,
 			},
-			hcat.NewStore(),
+			fakeWatcher{hcat.NewStore()},
 			"[a b c]",
 			false,
 		},
@@ -77,7 +77,7 @@ func TestStringExecute(t *testing.T) {
 			hcat.TemplateInput{
 				Contents: `{{ "hello my hello" | regexReplaceAll "hello" "bye" }}`,
 			},
-			hcat.NewStore(),
+			fakeWatcher{hcat.NewStore()},
 			"bye my bye",
 			false,
 		},
@@ -86,7 +86,7 @@ func TestStringExecute(t *testing.T) {
 			hcat.TemplateInput{
 				Contents: `{{ "foo" | regexReplaceAll "\\w" "x" }}`,
 			},
-			hcat.NewStore(),
+			fakeWatcher{hcat.NewStore()},
 			"xxx",
 			false,
 		},
@@ -95,7 +95,7 @@ func TestStringExecute(t *testing.T) {
 			hcat.TemplateInput{
 				Contents: `{{ "foo" | regexMatch "[a-z]+" }}`,
 			},
-			hcat.NewStore(),
+			fakeWatcher{hcat.NewStore()},
 			"true",
 			false,
 		},

--- a/tfunc/string_test.go
+++ b/tfunc/string_test.go
@@ -33,7 +33,7 @@ func TestStringExecute(t *testing.T) {
 				Contents: `{{ "hello\nhello\r\nHELLO\r\nhello\nHELLO" | indent -4 }}`,
 			},
 			fakeWatcher{hcat.NewStore()},
-			"    hello\n    hello\r\n    HELLO\r\n    hello\n    HELLO",
+			"",
 			true,
 		},
 		{
@@ -109,8 +109,8 @@ func TestStringExecute(t *testing.T) {
 			if (err != nil) != tc.err {
 				t.Fatal(err)
 			}
-			if a != nil && !bytes.Equal([]byte(tc.e), a.Output) {
-				t.Errorf("\nexp: %#v\nact: %#v", tc.e, string(a.Output))
+			if !bytes.Equal([]byte(tc.e), a) {
+				t.Errorf("\nexp: %#v\nact: %#v", tc.e, string(a))
 			}
 		})
 	}

--- a/tfunc/time_test.go
+++ b/tfunc/time_test.go
@@ -50,8 +50,8 @@ func TestTimeExecute(t *testing.T) {
 			if (err != nil) != tc.err {
 				t.Fatal(err)
 			}
-			if a != nil && !bytes.Equal([]byte(tc.e), a.Output) {
-				t.Errorf("\nexp: %#v\nact: %#v", tc.e, string(a.Output))
+			if !bytes.Equal([]byte(tc.e), a) {
+				t.Errorf("\nexp: %#v\nact: %#v", tc.e, string(a))
 			}
 		})
 	}

--- a/tfunc/time_test.go
+++ b/tfunc/time_test.go
@@ -18,7 +18,7 @@ func TestTimeExecute(t *testing.T) {
 	cases := []struct {
 		name string
 		ti   hcat.TemplateInput
-		i    hcat.Recaller
+		i    hcat.Watcherer
 		e    string
 		err  bool
 	}{
@@ -27,7 +27,7 @@ func TestTimeExecute(t *testing.T) {
 			hcat.TemplateInput{
 				Contents: `{{ timestamp }}`,
 			},
-			hcat.NewStore(),
+			fakeWatcher{hcat.NewStore()},
 			"1970-01-01T00:00:00Z",
 			false,
 		},
@@ -36,7 +36,7 @@ func TestTimeExecute(t *testing.T) {
 			hcat.TemplateInput{
 				Contents: `{{ timestamp "2006-01-02" }}`,
 			},
-			hcat.NewStore(),
+			fakeWatcher{hcat.NewStore()},
 			"1970-01-01",
 			false,
 		},

--- a/tfunc/transform_test.go
+++ b/tfunc/transform_test.go
@@ -136,8 +136,8 @@ func TestTransformExecute(t *testing.T) {
 			if (err != nil) != tc.err {
 				t.Fatal(err)
 			}
-			if a != nil && !bytes.Equal([]byte(tc.e), a.Output) {
-				t.Errorf("\nexp: %#v\nact: %#v", tc.e, string(a.Output))
+			if !bytes.Equal([]byte(tc.e), a) {
+				t.Errorf("\nexp: %#v\nact: %#v", tc.e, string(a))
 			}
 		})
 	}

--- a/tfunc/transform_test.go
+++ b/tfunc/transform_test.go
@@ -14,7 +14,7 @@ func TestTransformExecute(t *testing.T) {
 	cases := []struct {
 		name string
 		ti   hcat.TemplateInput
-		i    hcat.Recaller
+		i    hcat.Watcherer
 		e    string
 		err  bool
 	}{
@@ -23,7 +23,7 @@ func TestTransformExecute(t *testing.T) {
 			hcat.TemplateInput{
 				Contents: `{{ base64Decode "aGVsbG8=" }}`,
 			},
-			nil,
+			fakeWatcher{hcat.NewStore()},
 			"hello",
 			false,
 		},
@@ -32,7 +32,7 @@ func TestTransformExecute(t *testing.T) {
 			hcat.TemplateInput{
 				Contents: `{{ base64Decode "aGVsxxbG8=" }}`,
 			},
-			nil,
+			fakeWatcher{hcat.NewStore()},
 			"",
 			true,
 		},
@@ -41,7 +41,7 @@ func TestTransformExecute(t *testing.T) {
 			hcat.TemplateInput{
 				Contents: `{{ base64Encode "hello" }}`,
 			},
-			nil,
+			fakeWatcher{hcat.NewStore()},
 			"aGVsbG8=",
 			false,
 		},
@@ -50,7 +50,7 @@ func TestTransformExecute(t *testing.T) {
 			hcat.TemplateInput{
 				Contents: `{{ base64URLDecode "dGVzdGluZzEyMw==" }}`,
 			},
-			nil,
+			fakeWatcher{hcat.NewStore()},
 			"testing123",
 			false,
 		},
@@ -59,7 +59,7 @@ func TestTransformExecute(t *testing.T) {
 			hcat.TemplateInput{
 				Contents: `{{ base64URLDecode "aGVsxxbG8=" }}`,
 			},
-			nil,
+			fakeWatcher{hcat.NewStore()},
 			"",
 			true,
 		},
@@ -68,7 +68,7 @@ func TestTransformExecute(t *testing.T) {
 			hcat.TemplateInput{
 				Contents: `{{ base64URLEncode "testing123" }}`,
 			},
-			nil,
+			fakeWatcher{hcat.NewStore()},
 			"dGVzdGluZzEyMw==",
 			false,
 		},
@@ -77,7 +77,7 @@ func TestTransformExecute(t *testing.T) {
 			hcat.TemplateInput{
 				Contents: `{{ "a,b,c" | split "," | toJSON }}`,
 			},
-			hcat.NewStore(),
+			fakeWatcher{hcat.NewStore()},
 			"[\"a\",\"b\",\"c\"]",
 			false,
 		},
@@ -86,7 +86,7 @@ func TestTransformExecute(t *testing.T) {
 			hcat.TemplateInput{
 				Contents: `{{ "HI" | toLower }}`,
 			},
-			hcat.NewStore(),
+			fakeWatcher{hcat.NewStore()},
 			"hi",
 			false,
 		},
@@ -95,7 +95,7 @@ func TestTransformExecute(t *testing.T) {
 			hcat.TemplateInput{
 				Contents: `{{ "this is a sentence" | toTitle }}`,
 			},
-			hcat.NewStore(),
+			fakeWatcher{hcat.NewStore()},
 			"This Is A Sentence",
 			false,
 		},
@@ -104,7 +104,7 @@ func TestTransformExecute(t *testing.T) {
 			hcat.TemplateInput{
 				Contents: `{{ "{\"foo\":\"bar\"}" | parseJSON | toTOML }}`,
 			},
-			hcat.NewStore(),
+			fakeWatcher{hcat.NewStore()},
 			"foo = \"bar\"",
 			false,
 		},
@@ -113,7 +113,7 @@ func TestTransformExecute(t *testing.T) {
 			hcat.TemplateInput{
 				Contents: `{{ "hi" | toUpper }}`,
 			},
-			hcat.NewStore(),
+			fakeWatcher{hcat.NewStore()},
 			"HI",
 			false,
 		},
@@ -122,7 +122,7 @@ func TestTransformExecute(t *testing.T) {
 			hcat.TemplateInput{
 				Contents: `{{ "{\"foo\":\"bar\"}" | parseJSON | toYAML }}`,
 			},
-			hcat.NewStore(),
+			fakeWatcher{hcat.NewStore()},
 			"foo: bar",
 			false,
 		},

--- a/watcher.go
+++ b/watcher.go
@@ -530,7 +530,10 @@ func (t *tracker) notifiersFor(v *view) []Notifier {
 
 // initialized returns true if the view has had its data fetched at least once
 func (t *tracker) initialized(viewID string) bool {
-	return t.views[viewID].receivedData
+	if v, ok := t.views[viewID]; ok {
+		return v.receivedData
+	}
+	return false
 }
 
 // complete returns true if every dependency used has been initialized

--- a/watcher.go
+++ b/watcher.go
@@ -607,8 +607,3 @@ func (n *dummyNotifier) ids() []string {
 	}
 	return results
 }
-func (n *dummyNotifier) drain() {
-	for range n.deps {
-		// just draining
-	}
-}

--- a/watcher.go
+++ b/watcher.go
@@ -168,12 +168,6 @@ func (w *Watcher) WaitCh(ctx context.Context) <-chan error {
 func (w *Watcher) Wait(ctx context.Context) error {
 	w.stopCh.drain() // in case Stop was already called
 
-	//	sweepStop := make(chan struct{})
-	//	defer close(sweepStop) // only run while waiting
-	go func() {
-		//w.tracker.sweep()
-	}()
-
 	// send waiting notification, only used for testing
 	select {
 	case w.waitingCh <- struct{}{}:
@@ -456,7 +450,7 @@ func (t *tracker) notUsed(notifierID, viewID string) bool {
 	return false
 }
 
-// lookup returns the view and true, or view's zero value and false
+// lookup returns the view and true, or nil and false
 func (t *tracker) lookup(viewID string) (*view, bool) {
 	t.Lock()
 	defer t.Unlock()
@@ -541,8 +535,6 @@ func (t *tracker) initialized(viewID string) bool {
 func (t *tracker) complete(n Notifier) bool {
 	for _, tp := range t.tracked {
 		thisNotifier := tp.notify == n.ID()
-		//		fmt.Println(thisNotifier, tp.inUse, !t.initialized(tp.view))
-		//		fmt.Printf("%#v\n", tp)
 		if thisNotifier && tp.inUse && !t.initialized(tp.view) {
 			return false
 		}


### PR DESCRIPTION
Reworks how it keeps track of dependencies/views, templates and their relationships like which dependencies are used by which templates and visa versa.

2 main reasons for this.
1. to many objects with overlapping responsibilities, this cuts things down from ~6 objects to 1 (including sub-structs, ~10 to 3)
2. it eliminates the shared tracking of changes and localizes that to allow for per-template level checks

2 above will allow for per-template async management

Also includes some simplifications to the related interfaces as some methods were changed, added or made obsolete.
The resulting interfaces are smaller as well.
