### PR TITLE
abstract Recaller's argument to be a Notifier

### DIFF
--- a/resolver.go
+++ b/resolver.go
@@ -28,7 +28,7 @@ func NewResolver() *Resolver {
 // The interface is used to make the used/required API explicit.
 type Watcherer interface {
 	Buffer(tmplID string) bool
-	Recaller(*Template) Recaller
+	Recaller(Notifier) Recaller
 	Complete(Notifier) bool
 }
 

--- a/template_test.go
+++ b/template_test.go
@@ -717,7 +717,7 @@ type fakeWatcher struct {
 
 func (fakeWatcher) Buffer(string) bool       { return false }
 func (f fakeWatcher) Complete(Notifier) bool { return true }
-func (f fakeWatcher) Recaller(t *Template) Recaller {
+func (f fakeWatcher) Recaller(Notifier) Recaller {
 	return func(d dep.Dependency) (value interface{}, found bool) {
 		return f.Store.Recall(d.String())
 	}

--- a/tfunc/consul_test.go
+++ b/tfunc/consul_test.go
@@ -202,7 +202,7 @@ type fakeWatcher struct {
 
 func (fakeWatcher) Buffer(string) bool            { return false }
 func (f fakeWatcher) Complete(hcat.Notifier) bool { return true }
-func (f fakeWatcher) Recaller(t *hcat.Template) hcat.Recaller {
+func (f fakeWatcher) Recaller(hcat.Notifier) hcat.Recaller {
 	return func(d dep.Dependency) (value interface{}, found bool) {
 		return f.Store.Recall(d.String())
 	}

--- a/watcher.go
+++ b/watcher.go
@@ -300,9 +300,9 @@ func (w *Watcher) Poll(deps ...dep.Dependency) {
 
 // Recaller returns a Recaller (function) that wraps the Store (cache)
 // to enable tracking dependencies on the Watcher.
-func (w *Watcher) Recaller(tmpl *Template) Recaller {
+func (w *Watcher) Recaller(n Notifier) Recaller {
 	return func(dep dep.Dependency) (interface{}, bool) {
-		w.Register(tmpl, dep)
+		w.Register(n, dep)
 		data, ok := w.cache.Recall(dep.String())
 		if !ok {
 			w.Poll(dep)


### PR DESCRIPTION
It was *Template, which wasn't needed. Only the Notifier interface was
necessary and this fits the best-practive pattern (interfaces in).

I think I meant to do this before and forgot. It is an obvious change.