### PR TITLE
Failed register bug

### DIFF
--- a/resolver_test.go
+++ b/resolver_test.go
@@ -39,7 +39,7 @@ func TestResolverRun(t *testing.T) {
 		// otherwise it will trigger first run
 		w.Register(tt, d)
 		// set receivedData to true to make it think it has it already
-		v, _ := w.tracker.lookup(d.String())
+		v := w.tracker.view(d.String())
 		v.receivedData = true
 
 		r, err := rv.Run(tt, w)


### PR DESCRIPTION
This is to address and issue with failing to register the same view in combination with multiple notifiers (templates).

The issue was when multiple notifiers used the same dependency they wouldn't register properly as the test for existing entries only checked the dependency. Rework to check both and refactor old use of same method for view look-ups to a new 'view' method.