### PR TITLE
Add cancellable context to Fetch requests

### DIFF
--- a/internal/dependency/dependency.go
+++ b/internal/dependency/dependency.go
@@ -121,13 +121,6 @@ func (q *QueryOptions) Merge(o *QueryOptions) *QueryOptions {
 	return &r
 }
 
-func (q *QueryOptions) Context() context.Context {
-	if q != nil && q.ctx != nil {
-		return q.ctx
-	}
-	return context.Background()
-}
-
 func (q *QueryOptions) SetContext(ctx context.Context) QueryOptions {
 	var q2 QueryOptions
 	if q != nil {

--- a/internal/dependency/dependency.go
+++ b/internal/dependency/dependency.go
@@ -1,6 +1,7 @@
 package dependency
 
 import (
+	"context"
 	"net/url"
 	"regexp"
 	"sort"
@@ -72,6 +73,8 @@ type QueryOptions struct {
 	WaitIndex         uint64
 	WaitTime          time.Duration
 	DefaultLease      time.Duration
+
+	ctx context.Context
 }
 
 func (q *QueryOptions) Merge(o *QueryOptions) *QueryOptions {
@@ -118,8 +121,24 @@ func (q *QueryOptions) Merge(o *QueryOptions) *QueryOptions {
 	return &r
 }
 
+func (q *QueryOptions) Context() context.Context {
+	if q != nil && q.ctx != nil {
+		return q.ctx
+	}
+	return context.Background()
+}
+
+func (q *QueryOptions) SetContext(ctx context.Context) QueryOptions {
+	var q2 QueryOptions
+	if q != nil {
+		q2 = *q
+	}
+	q2.ctx = ctx
+	return q2
+}
+
 func (q *QueryOptions) ToConsulOpts() *consulapi.QueryOptions {
-	return &consulapi.QueryOptions{
+	cq := consulapi.QueryOptions{
 		AllowStale:        q.AllowStale,
 		Datacenter:        q.Datacenter,
 		Near:              q.Near,
@@ -127,6 +146,11 @@ func (q *QueryOptions) ToConsulOpts() *consulapi.QueryOptions {
 		WaitIndex:         q.WaitIndex,
 		WaitTime:          q.WaitTime,
 	}
+
+	if q.ctx != nil {
+		return cq.WithContext(q.ctx)
+	}
+	return &cq
 }
 
 func (q *QueryOptions) String() string {

--- a/internal/dependency/fakedep.go
+++ b/internal/dependency/fakedep.go
@@ -192,7 +192,7 @@ func (d *FakeDepBlockingQuery) Fetch(dep.Clients) (interface{}, *dep.ResponseMet
 	case <-d.stop:
 		return nil, nil, dep.ErrStopped
 	case <-time.After(d.BlockDuration):
-		return "this is some data", &dep.ResponseMetadata{LastIndex: 1}, nil
+		return d.Data, &dep.ResponseMetadata{LastIndex: 1}, nil
 	case <-d.Ctx.Done():
 		return nil, nil, d.Ctx.Err()
 	}

--- a/internal/dependency/health_service.go
+++ b/internal/dependency/health_service.go
@@ -3,7 +3,6 @@ package dependency
 import (
 	"encoding/gob"
 	"fmt"
-	"net/url"
 	"regexp"
 	"sort"
 	"strings"
@@ -114,16 +113,10 @@ func (d *HealthServiceQuery) Fetch(clients dep.Clients) (interface{}, *dep.Respo
 		Near:       d.near,
 	})
 
-	u := &url.URL{
-		Path:     "/v1/health/service/" + d.name,
-		RawQuery: opts.String(),
-	}
-	if d.tag != "" {
-		q := u.Query()
-		q.Set("tag", d.tag)
-		u.RawQuery = q.Encode()
-	}
-	//log.Printf("[TRACE] %s: GET %s", d, u)
+	//log.Printf("[TRACE] %s: GET %s", d, &url.URL{
+	//	Path:     "/v1/health/service/%d"+d.name,
+	//	RawQuery: opts.String(),
+	//})
 
 	// Check if a user-supplied filter was given. If so, we may be querying for
 	// more than healthy services, so we need to implement client-side

--- a/view.go
+++ b/view.go
@@ -3,7 +3,6 @@ package hcat
 import (
 	"context"
 	"fmt"
-	"log"
 	"math/rand"
 	"reflect"
 	"strings"
@@ -220,13 +219,13 @@ func (v *view) fetch(doneCh, successCh chan<- struct{}, errCh chan<- error) {
 		}
 		data, rm, err := v.dependency.Fetch(v.clients)
 		if err != nil {
-			if err == dep.ErrStopped {
+			switch {
+			case err == dep.ErrStopped:
 				//log.Printf("[TRACE] (view) %s reported stop", v.dependency)
-			} else if strings.Contains(err.Error(), context.Canceled.Error()) {
+			case strings.Contains(err.Error(), context.Canceled.Error()):
 				// This is a wrapped error so relying on string matching
 				// log.Printf("[TRACE] (view) %s request context stopped", v.dependency)
-			} else {
-				log.Printf("[TRACE] (view) Fetch error: %s", err)
+			default:
 				errCh <- err
 			}
 			return

--- a/view.go
+++ b/view.go
@@ -1,9 +1,12 @@
 package hcat
 
 import (
+	"context"
 	"fmt"
+	"log"
 	"math/rand"
 	"reflect"
+	"strings"
 	"sync"
 	"time"
 
@@ -43,6 +46,14 @@ type view struct {
 
 	// stopCh is used to stop polling on this view
 	stopCh chan struct{}
+
+	// Each view has a context used to cancel an in-flight HTTP request. This is
+	// a no-op if there is not an active request. Canceling is required to release
+	// the underlying TCP connections used by Consul blocking queries that are
+	// waiting for changes from the server. It allows for the http.Transport to
+	// change the TCP connection status from active to idle, to then be reaped.
+	ctx       context.Context
+	ctxCancel context.CancelFunc
 }
 
 // NewViewInput is used as input to the NewView function.
@@ -68,6 +79,7 @@ type newViewInput struct {
 
 // NewView constructs a new view with the given inputs.
 func newView(i *newViewInput) *view {
+	ctx, cancel := context.WithCancel(context.Background())
 	return &view{
 		dependency:    i.Dependency,
 		clients:       i.Clients,
@@ -75,6 +87,8 @@ func newView(i *newViewInput) *view {
 		maxStale:      i.MaxStale,
 		retryFunc:     i.RetryFunc,
 		stopCh:        make(chan struct{}, 1),
+		ctx:           ctx,
+		ctxCancel:     cancel,
 	}
 }
 
@@ -187,24 +201,32 @@ func (v *view) fetch(doneCh, successCh chan<- struct{}, errCh chan<- error) {
 		select {
 		case <-v.stopCh:
 			return
+		case <-v.ctx.Done():
+			return
 		default:
 		}
 
 		start := time.Now() // for rateLimiter below
 
 		if d, ok := v.dependency.(idep.QueryOptionsSetter); ok {
-			d.SetOptions(idep.QueryOptions{
+			opts := idep.QueryOptions{
 				AllowStale:   allowStale,
 				WaitTime:     v.blockWaitTime,
 				WaitIndex:    v.lastIndex,
 				DefaultLease: v.defaultLease,
-			})
+			}
+			opts = opts.SetContext(v.ctx)
+			d.SetOptions(opts)
 		}
 		data, rm, err := v.dependency.Fetch(v.clients)
 		if err != nil {
 			if err == dep.ErrStopped {
 				//log.Printf("[TRACE] (view) %s reported stop", v.dependency)
+			} else if strings.Contains(err.Error(), context.Canceled.Error()) {
+				// This is a wrapped error so relying on string matching
+				// log.Printf("[TRACE] (view) %s request context stopped", v.dependency)
 			} else {
+				log.Printf("[TRACE] (view) Fetch error: %s", err)
 				errCh <- err
 			}
 			return
@@ -291,4 +313,5 @@ func rateLimiter(start time.Time) time.Duration {
 func (v *view) stop() {
 	v.dependency.Stop()
 	close(v.stopCh)
+	v.ctxCancel()
 }

--- a/view_test.go
+++ b/view_test.go
@@ -224,6 +224,7 @@ func TestFetch_ctxCancel(t *testing.T) {
 	case <-errCh:
 		t.Errorf("unexpected errCh")
 	case <-time.After(5 * time.Millisecond):
+		// Nothing expected in any of these channels
 		ctxCancel()
 	}
 
@@ -284,9 +285,11 @@ func TestStop_stopsFetchWithCancel(t *testing.T) {
 	case <-errCh:
 		t.Errorf("unexpected errCh")
 	case <-time.After(5 * time.Millisecond):
-		// Successfully stopped by context
-		wg.Wait()
+		// Nothing expected in any of these channels
 	}
+
+	// Successfully stopped by context
+	wg.Wait()
 }
 
 func TestRateLimiter(t *testing.T) {

--- a/view_test.go
+++ b/view_test.go
@@ -1,7 +1,9 @@
 package hcat
 
 import (
+	"context"
 	"reflect"
+	"sync"
 	"testing"
 	"time"
 
@@ -193,6 +195,42 @@ func TestFetch_returnsErrCh(t *testing.T) {
 	}
 }
 
+func TestFetch_ctxCancel(t *testing.T) {
+	ctx, ctxCancel := context.WithCancel(context.Background())
+	view := newView(&newViewInput{
+		Dependency: &dep.FakeDepBlockingQuery{
+			Name:          "ctxCancel",
+			BlockDuration: time.Duration(5 * time.Minute),
+			Ctx:           ctx,
+		},
+	})
+
+	doneCh := make(chan struct{})
+	successCh := make(chan struct{})
+	errCh := make(chan error)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		view.fetch(doneCh, successCh, errCh)
+		wg.Done()
+	}()
+
+	select {
+	case <-doneCh:
+		t.Errorf("unexpected doneCh")
+	case <-successCh:
+		t.Errorf("unexpected successCh")
+	case <-errCh:
+		t.Errorf("unexpected errCh")
+	case <-time.After(5 * time.Millisecond):
+		ctxCancel()
+	}
+
+	// Successfully stopped by context
+	wg.Wait()
+}
+
 func TestStop_stopsPolling(t *testing.T) {
 	vw := newView(&newViewInput{
 		Dependency: &dep.FakeDep{},
@@ -211,6 +249,43 @@ func TestStop_stopsPolling(t *testing.T) {
 		t.Error(err)
 	case <-vw.stopCh:
 		// Successfully stopped
+	}
+}
+
+func TestStop_stopsFetchWithCancel(t *testing.T) {
+	ctx, ctxCancel := context.WithCancel(context.Background())
+	view := newView(&newViewInput{
+		Dependency: &dep.FakeDepBlockingQuery{
+			Name:          "ctxCancel",
+			BlockDuration: time.Duration(5 * time.Minute),
+			Ctx:           ctx,
+		},
+	})
+	view.ctxCancel = ctxCancel
+
+	doneCh := make(chan struct{})
+	successCh := make(chan struct{})
+	errCh := make(chan error)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		view.fetch(doneCh, successCh, errCh)
+		wg.Done()
+	}()
+
+	view.stop()
+
+	select {
+	case <-doneCh:
+		t.Errorf("unexpected doneCh")
+	case <-successCh:
+		t.Errorf("unexpected successCh")
+	case <-errCh:
+		t.Errorf("unexpected errCh")
+	case <-time.After(5 * time.Millisecond):
+		// Successfully stopped by context
+		wg.Wait()
 	}
 }
 


### PR DESCRIPTION
Fetch requests that are Consul blocking queries leak on shutdown and hold onto the TCP connection causing Consul server to also hold until reaped. This can quickly result in reaching Consul client connection limits and causing subsequent client restarts to error due to agent rate limits, 429 and EOFs.

The PR adds a cancellable context to the QueryOptions for the Consul API client to use for HTTP requests. This allows `view.Stop()` to cancel the context which cancels the in-flight request. Canceling the request releases the underlying TCP connection from active to now possible idle state, which could then be cleaned up when `ClientSet.Stop()` -> `http.Client.CloseIdleConnections()` is called.