### PR TITLE
View overwrite bug

### DIFF
--- a/watcher.go
+++ b/watcher.go
@@ -473,8 +473,12 @@ func (t *tracker) view(viewID string) *view {
 func (t *tracker) add(v *view, n Notifier) {
 	t.Lock()
 	defer t.Unlock()
-	t.views[v.ID()] = v
-	t.notifiers[n.ID()] = n
+	if _, ok := t.views[v.ID()]; !ok {
+		t.views[v.ID()] = v
+	}
+	if _, ok := t.notifiers[n.ID()]; !ok {
+		t.notifiers[n.ID()] = n
+	}
 	t.tracked = append(t.tracked,
 		trackedPair{view: v.ID(), notify: n.ID(), inUse: true})
 }

--- a/watcher_test.go
+++ b/watcher_test.go
@@ -110,7 +110,14 @@ func TestWatcherWatching(t *testing.T) {
 		n0 := fakeNotifier("foo")
 		n1 := fakeNotifier("bar")
 		w.Register(n0, d)
+		v0 := w.tracker.view(d.String())
 		w.Register(n1, d)
+		v1 := w.tracker.view(d.String())
+
+		// be sure view created for dependency is reused
+		if v0 != v1 {
+			t.Errorf("previous view overwritten, should reuse first one")
+		}
 
 		if w.Watching(d.String()) == false {
 			t.Errorf("expected to be Watching")


### PR DESCRIPTION
Fixes issue where 2 notifiers are registered with the same dependency and it creates a new view for the second, overwriting the first.
