### PR TITLE
add 'Kind' to health service data struct

### DIFF
--- a/dep/template_function_types.go
+++ b/dep/template_function_types.go
@@ -54,6 +54,7 @@ type HealthService struct {
 	Address             string
 	ID                  string
 	Name                string
+	Kind                string
 	Tags                ServiceTags
 	Checks              api.HealthChecks
 	Status              string

--- a/internal/dependency/health_service.go
+++ b/internal/dependency/health_service.go
@@ -155,6 +155,7 @@ func (d *HealthServiceQuery) Fetch(clients dep.Clients) (interface{}, *dep.Respo
 		list = append(list, &dep.HealthService{
 			Node:                entry.Node.Node,
 			NodeID:              entry.Node.ID,
+			Kind:                string(entry.Service.Kind),
 			NodeAddress:         entry.Node.Address,
 			NodeDatacenter:      entry.Node.Datacenter,
 			NodeTaggedAddresses: entry.Node.TaggedAddresses,

--- a/internal/dependency/health_service_test.go
+++ b/internal/dependency/health_service_test.go
@@ -176,6 +176,7 @@ func TestHealthConnectServiceQuery_Fetch(t *testing.T) {
 				&dep.HealthService{
 					Name:           "foo-sidecar-proxy",
 					ID:             "foo",
+					Kind:           "connect-proxy",
 					Port:           21999,
 					Status:         "passing",
 					Address:        "127.0.0.1",


### PR DESCRIPTION
Kind is blank by default, only used for new "non-standard" services, such as: connect-proxy, mesh-gateway, terminating-gateway, ingress-gateway.

Required for https://github.com/hashicorp/consul-terraform-sync/issues/168