### PR TITLE
Service namespace

### DIFF
--- a/consul_v1.go
+++ b/consul_v1.go
@@ -1,0 +1,77 @@
+package hcat
+
+import (
+	"fmt"
+	"text/template"
+
+	"github.com/hashicorp/hcat/dep"
+	idep "github.com/hashicorp/hcat/internal/dependency"
+)
+
+var errFuncNotImplemented = fmt.Errorf("function is not implemented")
+
+func FuncMapConsulV1(recaller Recaller) template.FuncMap {
+	r := template.FuncMap{
+		"service": v1ServiceFunc(recaller),
+		"connect": v1ConnectFunc(recaller),
+
+		// Set of Consul functions that are not yet implemented for v1. These
+		// intentionally error instead of defaulting to the v0 implementations
+		// to avoid introducing breaking changes when they are supported.
+		"node":     v1TODOFunc(recaller),
+		"nodes":    v1TODOFunc(recaller),
+		"services": v1TODOFunc(recaller),
+	}
+	return r
+}
+
+func v1TODOFunc(recall Recaller) func(...string) (interface{}, error) {
+	return func(s ...string) (interface{}, error) {
+		return nil, errFuncNotImplemented
+	}
+}
+
+// v1ServiceFunc returns or accumulates health service dependencies.
+// /v1/health/service/:service
+func v1ServiceFunc(recall Recaller) func(string, ...string) ([]*dep.HealthService, error) {
+	return func(service string, opts ...string) ([]*dep.HealthService, error) {
+		result := []*dep.HealthService{}
+
+		if service == "" {
+			return result, nil
+		}
+
+		d, err := idep.NewHealthServiceQueryV1(service, opts)
+		if err != nil {
+			return nil, err
+		}
+
+		if value, ok := recall(d); ok {
+			return value.([]*dep.HealthService), nil
+		}
+
+		return result, nil
+	}
+}
+
+// v1ConnectFunc returns or accumulates health connect dependencies.
+func v1ConnectFunc(recall Recaller) func(string, ...string) ([]*dep.HealthService, error) {
+	return func(service string, opts ...string) ([]*dep.HealthService, error) {
+		result := []*dep.HealthService{}
+
+		if service == "" {
+			return result, nil
+		}
+
+		d, err := idep.NewHealthConnectQueryV1(service, opts)
+		if err != nil {
+			return nil, err
+		}
+
+		if value, ok := recall(d); ok {
+			return value.([]*dep.HealthService), nil
+		}
+
+		return result, nil
+	}
+}

--- a/consul_v1.go
+++ b/consul_v1.go
@@ -10,22 +10,21 @@ import (
 
 var errFuncNotImplemented = fmt.Errorf("function is not implemented")
 
-func FuncMapConsulV1(recaller Recaller) template.FuncMap {
-	r := template.FuncMap{
-		"service": v1ServiceFunc(recaller),
-		"connect": v1ConnectFunc(recaller),
+func FuncMapConsulV1() template.FuncMap {
+	return template.FuncMap{
+		"service": v1ServiceFunc,
+		"connect": v1ConnectFunc,
 
 		// Set of Consul functions that are not yet implemented for v1. These
 		// intentionally error instead of defaulting to the v0 implementations
 		// to avoid introducing breaking changes when they are supported.
-		"node":     v1TODOFunc(recaller),
-		"nodes":    v1TODOFunc(recaller),
-		"services": v1TODOFunc(recaller),
+		"node":     v1TODOFunc,
+		"nodes":    v1TODOFunc,
+		"services": v1TODOFunc,
 	}
-	return r
 }
 
-func v1TODOFunc(recall Recaller) func(...string) (interface{}, error) {
+func v1TODOFunc(recall Recaller) interface{} {
 	return func(s ...string) (interface{}, error) {
 		return nil, errFuncNotImplemented
 	}
@@ -33,7 +32,7 @@ func v1TODOFunc(recall Recaller) func(...string) (interface{}, error) {
 
 // v1ServiceFunc returns or accumulates health service dependencies.
 // /v1/health/service/:service
-func v1ServiceFunc(recall Recaller) func(string, ...string) ([]*dep.HealthService, error) {
+func v1ServiceFunc(recall Recaller) interface{} {
 	return func(service string, opts ...string) ([]*dep.HealthService, error) {
 		result := []*dep.HealthService{}
 
@@ -55,7 +54,7 @@ func v1ServiceFunc(recall Recaller) func(string, ...string) ([]*dep.HealthServic
 }
 
 // v1ConnectFunc returns or accumulates health connect dependencies.
-func v1ConnectFunc(recall Recaller) func(string, ...string) ([]*dep.HealthService, error) {
+func v1ConnectFunc(recall Recaller) interface{} {
 	return func(service string, opts ...string) ([]*dep.HealthService, error) {
 		result := []*dep.HealthService{}
 

--- a/consul_v1.go
+++ b/consul_v1.go
@@ -10,6 +10,9 @@ import (
 
 var errFuncNotImplemented = fmt.Errorf("function is not implemented")
 
+// FuncMapConsulV1 is a set of template functions for querying Consul endpoints.
+// The functions support Consul v1 API filter expressions and Consul enterprise
+// namespaces.
 func FuncMapConsulV1() template.FuncMap {
 	return template.FuncMap{
 		"service": v1ServiceFunc,
@@ -24,14 +27,18 @@ func FuncMapConsulV1() template.FuncMap {
 	}
 }
 
+// v1TODOFunc is a placeholder function to return an error instead of inheriting
+// the default template functions.
 func v1TODOFunc(recall Recaller) interface{} {
 	return func(s ...string) (interface{}, error) {
 		return nil, errFuncNotImplemented
 	}
 }
 
-// v1ServiceFunc returns or accumulates health service dependencies.
-// /v1/health/service/:service
+// v1ServiceFunc returns or accumulates health information of Consul services.
+//
+// Endpoint: /v1/health/service/:service
+// Template: {{ service "serviceName" <filter options> ... }}
 func v1ServiceFunc(recall Recaller) interface{} {
 	return func(service string, opts ...string) ([]*dep.HealthService, error) {
 		result := []*dep.HealthService{}
@@ -53,7 +60,12 @@ func v1ServiceFunc(recall Recaller) interface{} {
 	}
 }
 
-// v1ConnectFunc returns or accumulates health connect dependencies.
+// v1ConnectFunc returns or accumulates health information of datacenter nodes
+// and its services that are in Consul Connect, the the service mesh collection
+// of Consul.
+//
+// Endpoint: /v1/health/connect/:service
+// Template: {{ connect "serviceName" <filter options> ... }}
 func v1ConnectFunc(recall Recaller) interface{} {
 	return func(service string, opts ...string) ([]*dep.HealthService, error) {
 		result := []*dep.HealthService{}

--- a/consul_v1_test.go
+++ b/consul_v1_test.go
@@ -117,10 +117,7 @@ func TestTemplateExecute_consul_v1(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			recaller := func(dep dep.Dependency) (interface{}, bool) {
-				return tc.i.Recall(dep.String())
-			}
-			tc.ti.FuncMapMerge = FuncMapConsulV1(recaller)
+			tc.ti.FuncMapMerge = FuncMapConsulV1()
 			tpl := NewTemplate(tc.ti)
 
 			w := fakeWatcher{tc.i}

--- a/consul_v1_test.go
+++ b/consul_v1_test.go
@@ -1,0 +1,138 @@
+package hcat
+
+import (
+	"testing"
+
+	"github.com/hashicorp/hcat/dep"
+	idep "github.com/hashicorp/hcat/internal/dependency"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTemplateExecute_consul_v1(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		ti   TemplateInput
+		i    *Store
+		e    string
+		err  bool
+	}{
+		{
+			"func_service",
+			TemplateInput{
+				Contents: `{{ range service "webapp" "ns=namespace" }}{{ .Address }}{{ end }}`,
+			},
+			func() *Store {
+				st := NewStore()
+				d, err := idep.NewHealthConnectQueryV1("webapp", []string{"ns=namespace"})
+				if err != nil {
+					t.Fatal(err)
+				}
+				st.Save(d.String(), []*dep.HealthService{
+					{
+						Node:      "node1",
+						Address:   "1.2.3.4",
+						Namespace: "namespace",
+					},
+					{
+						Node:      "node2",
+						Address:   "5.6.7.8",
+						Namespace: "namespace",
+					},
+				})
+				return st
+			}(),
+			"1.2.3.45.6.7.8",
+			false,
+		}, {
+			"func_connect",
+			TemplateInput{
+				Contents: `{{ range connect "webapp" "ns=namespace" }}{{ .Address }}{{ end }}`,
+			},
+			func() *Store {
+				st := NewStore()
+				d, err := idep.NewHealthConnectQueryV1("webapp", []string{"ns=namespace"})
+				if err != nil {
+					t.Fatal(err)
+				}
+				st.Save(d.String(), []*dep.HealthService{
+					{
+						Node:      "node1",
+						Address:   "1.2.3.4",
+						Namespace: "namespace",
+					},
+					{
+						Node:      "node2",
+						Address:   "5.6.7.8",
+						Namespace: "namespace",
+					},
+				})
+				return st
+			}(),
+			"1.2.3.45.6.7.8",
+			false,
+		}, {
+			"func_node",
+			TemplateInput{
+				Contents: `{{ with node }}{{ .Node.Node }}{{ range .Services }}{{ .Service }}{{ end }}{{ end }}`,
+			},
+			nil,
+			"",
+			true,
+		}, {
+			"func_nodes",
+			TemplateInput{
+				Contents: `{{ range nodes }}{{ .Node }}{{ end }}`,
+			},
+			nil,
+			"",
+			true,
+		}, {
+			"func_services",
+			TemplateInput{
+				Contents: `{{ range services }}{{ .Name }}{{ end }}`,
+			},
+			nil,
+			"",
+			true,
+		}, {
+			"func_datacenters_v0",
+			TemplateInput{
+				Contents: `{{ datacenters }}`,
+			},
+			func() *Store {
+				st := NewStore()
+				d, err := idep.NewCatalogDatacentersQuery(false)
+				if err != nil {
+					t.Fatal(err)
+				}
+				st.Save(d.String(), []string{"dc1", "dc2"})
+				return st
+			}(),
+			"[dc1 dc2]",
+			false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			recaller := func(dep dep.Dependency) (interface{}, bool) {
+				return tc.i.Recall(dep.String())
+			}
+			tc.ti.FuncMapMerge = FuncMapConsulV1(recaller)
+			tpl := NewTemplate(tc.ti)
+
+			w := fakeWatcher{tc.i}
+			a, err := tpl.Execute(w)
+			if tc.err {
+				assert.Error(t, err, "expected: funcNotImplementedError")
+				assert.Contains(t, err.Error(), errFuncNotImplemented.Error())
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tc.e, string(a))
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/google/btree v1.0.0 // indirect
 	github.com/hashicorp/consul/api v1.4.0
 	github.com/hashicorp/consul/sdk v0.4.0
+	github.com/hashicorp/go-bexpr v0.1.4
 	github.com/hashicorp/go-gatedio v0.5.0
 	github.com/hashicorp/go-hclog v0.12.2 // indirect
 	github.com/hashicorp/go-immutable-radix v1.2.0 // indirect
@@ -22,7 +23,7 @@ require (
 	github.com/mitchellh/mapstructure v1.3.0 // indirect
 	github.com/pierrec/lz4 v2.5.2+incompatible // indirect
 	github.com/pkg/errors v0.9.1
-	github.com/stretchr/testify v1.5.1
+	github.com/stretchr/testify v1.6.1
 	golang.org/x/crypto v0.0.0-20200429183012-4b2356b1ed79 // indirect
 	golang.org/x/net v0.0.0-20200506145744-7e3656a0809f // indirect
 	golang.org/x/sys v0.0.0-20200501145240-bc7a7d42d5c3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -59,6 +59,8 @@ github.com/hashicorp/consul/sdk v0.4.0 h1:zBtCfKJZcJDBvSCkQJch4ulp59m1rATFLKwNo/
 github.com/hashicorp/consul/sdk v0.4.0/go.mod h1:fY08Y9z5SvJqevyZNy6WWPXiG3KwBPAvlcdx16zZ0fM=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/go-bexpr v0.1.4 h1:vyQpuKqqc+Ywb8tf6vZSlkf5qhYkgrNSWURtQggCfLE=
+github.com/hashicorp/go-bexpr v0.1.4/go.mod h1:ey7VZGNrY1PnLlYp6Nf3RLEizPo0B9W4yw2MnDkcK3M=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVoDkXMzJM=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
@@ -162,6 +164,8 @@ github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQz
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.3.0 h1:iDwIio/3gk2QtLLEsqU5lInaMzos0hDTz8a6lazSFVw=
 github.com/mitchellh/mapstructure v1.3.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+github.com/mitchellh/pointerstructure v1.1.0 h1:6RI+cKHSIOOuMhKALJyMIpGOHsmBGGwS0ZSMCPFn/jM=
+github.com/mitchellh/pointerstructure v1.1.0/go.mod h1:zoQzmW5t87ncZZuJWXEyhr0///POW/WQEeFG4RRVKEs=
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -209,6 +213,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181029021203-45a5f77698d3/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
@@ -303,5 +309,7 @@ gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.5/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/internal/dependency/dependency.go
+++ b/internal/dependency/dependency.go
@@ -67,6 +67,8 @@ type QueryOptionsSetter interface {
 type QueryOptions struct {
 	AllowStale        bool
 	Datacenter        string
+	Filter            string
+	Namespace         string
 	Near              string
 	RequireConsistent bool
 	VaultGrace        time.Duration
@@ -102,6 +104,14 @@ func (q *QueryOptions) Merge(o *QueryOptions) *QueryOptions {
 		r.Datacenter = o.Datacenter
 	}
 
+	if o.Filter != "" {
+		r.Filter = o.Filter
+	}
+
+	if o.Namespace != "" {
+		r.Namespace = o.Namespace
+	}
+
 	if o.Near != "" {
 		r.Near = o.Near
 	}
@@ -134,6 +144,8 @@ func (q *QueryOptions) ToConsulOpts() *consulapi.QueryOptions {
 	cq := consulapi.QueryOptions{
 		AllowStale:        q.AllowStale,
 		Datacenter:        q.Datacenter,
+		Filter:            q.Filter,
+		Namespace:         q.Namespace,
 		Near:              q.Near,
 		RequireConsistent: q.RequireConsistent,
 		WaitIndex:         q.WaitIndex,
@@ -155,6 +167,14 @@ func (q *QueryOptions) String() string {
 
 	if q.Datacenter != "" {
 		u.Add("dc", q.Datacenter)
+	}
+
+	if q.Filter != "" {
+		u.Add("filter", q.Filter)
+	}
+
+	if q.Namespace != "" {
+		u.Add("ns", q.Namespace)
 	}
 
 	if q.Near != "" {

--- a/internal/dependency/health_service.go
+++ b/internal/dependency/health_service.go
@@ -53,8 +53,14 @@ type HealthServiceQuery struct {
 	connect bool
 	opts    QueryOptions
 
+	// deprecatedStatusFilters is a list of check statuses for client-side
+	// filtering. Accepted values are the Health* constants above.
 	deprecatedStatusFilters []string
-	deprecatedTag           string
+
+	// deprecatedTag is the singular tag parsed from the template argument
+	// {{ service "tag.service" }} used for the deprecated tag query parameter.
+	// Use the filter parameter with the "Service.Tags" selector instead.
+	deprecatedTag string
 }
 
 // NewHealthServiceQueryV1 processes the strings to build a service dependency.

--- a/internal/dependency/health_service.go
+++ b/internal/dependency/health_service.go
@@ -33,7 +33,7 @@ var (
 	// queryParamOptRe is the regular expression to distinguish between query
 	// params and filters. Query parameters only have one "=" where as filters
 	// can have "==" or "!=" operators.
-	queryParamOptRe = regexp.MustCompile(`\w*[^!]={1}\w*`)
+	queryParamOptRe = regexp.MustCompile(`[\w\d\s]=[\w\d\s]`)
 )
 
 func init() {

--- a/internal/dependency/health_service_test.go
+++ b/internal/dependency/health_service_test.go
@@ -48,7 +48,6 @@ func TestNewHealthServiceQuery(t *testing.T) {
 			&HealthServiceQuery{
 				deprecatedStatusFilters: []string{"passing"},
 				name:                    "name",
-				passingOnly:             true,
 			},
 			false,
 		},
@@ -59,7 +58,6 @@ func TestNewHealthServiceQuery(t *testing.T) {
 				dc:                      "dc1",
 				deprecatedStatusFilters: []string{"passing"},
 				name:                    "name",
-				passingOnly:             true,
 			},
 			false,
 		},
@@ -71,7 +69,6 @@ func TestNewHealthServiceQuery(t *testing.T) {
 				deprecatedStatusFilters: []string{"passing"},
 				name:                    "name",
 				near:                    "near",
-				passingOnly:             true,
 			},
 			false,
 		},
@@ -82,7 +79,6 @@ func TestNewHealthServiceQuery(t *testing.T) {
 				deprecatedStatusFilters: []string{"passing"},
 				name:                    "name",
 				near:                    "near",
-				passingOnly:             true,
 			},
 			false,
 		},
@@ -93,7 +89,6 @@ func TestNewHealthServiceQuery(t *testing.T) {
 				deprecatedStatusFilters: []string{"passing"},
 				name:                    "name",
 				deprecatedTag:           "tag",
-				passingOnly:             true,
 			},
 			false,
 		},
@@ -105,7 +100,6 @@ func TestNewHealthServiceQuery(t *testing.T) {
 				deprecatedStatusFilters: []string{"passing"},
 				name:                    "name",
 				deprecatedTag:           "tag",
-				passingOnly:             true,
 			},
 			false,
 		},
@@ -117,7 +111,6 @@ func TestNewHealthServiceQuery(t *testing.T) {
 				name:                    "name",
 				near:                    "near",
 				deprecatedTag:           "tag",
-				passingOnly:             true,
 			},
 			false,
 		},
@@ -130,7 +123,6 @@ func TestNewHealthServiceQuery(t *testing.T) {
 				name:                    "name",
 				near:                    "near",
 				deprecatedTag:           "tag",
-				passingOnly:             true,
 			},
 			false,
 		},
@@ -163,7 +155,6 @@ func TestNewHealthServiceQuery(t *testing.T) {
 		exp := &HealthServiceQuery{
 			deprecatedStatusFilters: []string{"passing"},
 			name:                    "name",
-			passingOnly:             true,
 			connect:                 true,
 		}
 
@@ -465,68 +456,63 @@ func TestNewHealthServiceQueryV1(t *testing.T) {
 			"no opts",
 			[]string{},
 			&HealthServiceQuery{
-				name:        "name",
-				filter:      "Status == passing",
-				passingOnly: true,
+				name:   "name",
+				filter: `Checks.Status == "passing"`,
 			},
 			false,
 		}, {
 			"dc",
 			[]string{"dc=dc"},
 			&HealthServiceQuery{
-				name:        "name",
-				dc:          "dc",
-				filter:      "Status == passing",
-				passingOnly: true,
+				name:   "name",
+				dc:     "dc",
+				filter: `Checks.Status == "passing"`,
 			},
 			false,
 		}, {
 			"near",
 			[]string{"near=near"},
 			&HealthServiceQuery{
-				name:        "name",
-				near:        "near",
-				filter:      "Status == passing",
-				passingOnly: true,
+				name:   "name",
+				near:   "near",
+				filter: `Checks.Status == "passing"`,
 			},
 			false,
 		}, {
 			"namespace",
 			[]string{"ns=ns"},
 			&HealthServiceQuery{
-				name:        "name",
-				ns:          "ns",
-				filter:      "Status == passing",
-				passingOnly: true,
+				name:   "name",
+				ns:     "ns",
+				filter: `Checks.Status == "passing"`,
 			},
 			false,
 		}, {
 			"multiple queries",
 			[]string{"ns=ns", "dc=dc", "near=near"},
 			&HealthServiceQuery{
-				name:        "name",
-				dc:          "dc",
-				near:        "near",
-				ns:          "ns",
-				filter:      "Status == passing",
-				passingOnly: true,
+				name:   "name",
+				dc:     "dc",
+				near:   "near",
+				ns:     "ns",
+				filter: `Checks.Status == "passing"`,
 			},
 			false,
 		}, {
 			"filters",
-			[]string{"Status != passing", "\"my-tag\" in ServiceTags"},
+			[]string{"Checks.Status != passing", "\"my-tag\" in Service.Tags"},
 			&HealthServiceQuery{
 				name:   "name",
-				filter: "Status != passing and \"my-tag\" in ServiceTags",
+				filter: "Checks.Status != passing and \"my-tag\" in Service.Tags",
 			},
 			false,
 		}, {
 			"query and filter",
-			[]string{"dc=dc", "\"my-tag\" in ServiceTags", "\"another-tag\" in ServiceTags"},
+			[]string{"dc=dc", "\"my-tag\" in Service.Tags", "\"another-tag\" in Service.Tags"},
 			&HealthServiceQuery{
 				name:   "name",
 				dc:     "dc",
-				filter: "\"my-tag\" in ServiceTags and \"another-tag\" in ServiceTags",
+				filter: "\"my-tag\" in Service.Tags and \"another-tag\" in Service.Tags and Checks.Status == \"passing\"",
 			},
 			false,
 		}, {
@@ -536,7 +522,7 @@ func TestNewHealthServiceQueryV1(t *testing.T) {
 			true,
 		}, {
 			"invalid filter grammar",
-			[]string{"ServiceTags === tag"},
+			[]string{"Service.Tags === tag"},
 			nil,
 			true,
 		}, {
@@ -572,10 +558,9 @@ func TestNewHealthServiceQueryV1(t *testing.T) {
 			act.stopCh = nil
 		}
 		exp := &HealthServiceQuery{
-			filter:      "Status == passing",
-			name:        "name",
-			passingOnly: true,
-			connect:     true,
+			filter:  "Checks.Status == \"passing\"",
+			name:    "name",
+			connect: true,
 		}
 
 		assert.NoError(t, err)
@@ -594,23 +579,23 @@ func TestHealthServiceQueryV1_String(t *testing.T) {
 		{
 			"name",
 			[]string{},
-			`health.service(name?filter="Status == passing")`,
+			`health.service(name?filter=Checks.Status == "passing")`,
 		}, {
 			"dc",
 			[]string{"dc=dc"},
-			`health.service(name@dc?filter="Status == passing")`,
+			`health.service(name@dc?filter=Checks.Status == "passing")`,
 		}, {
 			"near",
 			[]string{"near=agent"},
-			`health.service(name~agent?filter="Status == passing")`,
+			`health.service(name~agent?filter=Checks.Status == "passing")`,
 		}, {
 			"ns",
 			[]string{"ns=ns"},
-			`health.service(name?ns=ns&filter="Status == passing")`,
+			`health.service(name?ns=ns&filter=Checks.Status == "passing")`,
 		}, {
 			"multifilter",
-			[]string{"Status contains passing", "mytag in ServiceTags"},
-			`health.service(name?filter="Status contains passing and mytag in ServiceTags")`,
+			[]string{"Checks.Status != passing", "mytag in Service.Tags"},
+			`health.service(name?filter=Checks.Status != passing and mytag in Service.Tags)`,
 		},
 	}
 

--- a/internal/dependency/health_service_test.go
+++ b/internal/dependency/health_service_test.go
@@ -46,8 +46,9 @@ func TestNewHealthServiceQuery(t *testing.T) {
 			"name",
 			"name",
 			&HealthServiceQuery{
-				filters: []string{"passing"},
-				name:    "name",
+				deprecatedStatusFilters: []string{"passing"},
+				name:                    "name",
+				passingOnly:             true,
 			},
 			false,
 		},
@@ -55,9 +56,10 @@ func TestNewHealthServiceQuery(t *testing.T) {
 			"name_dc",
 			"name@dc1",
 			&HealthServiceQuery{
-				dc:      "dc1",
-				filters: []string{"passing"},
-				name:    "name",
+				dc:                      "dc1",
+				deprecatedStatusFilters: []string{"passing"},
+				name:                    "name",
+				passingOnly:             true,
 			},
 			false,
 		},
@@ -65,10 +67,11 @@ func TestNewHealthServiceQuery(t *testing.T) {
 			"name_dc_near",
 			"name@dc1~near",
 			&HealthServiceQuery{
-				dc:      "dc1",
-				filters: []string{"passing"},
-				name:    "name",
-				near:    "near",
+				dc:                      "dc1",
+				deprecatedStatusFilters: []string{"passing"},
+				name:                    "name",
+				near:                    "near",
+				passingOnly:             true,
 			},
 			false,
 		},
@@ -76,9 +79,10 @@ func TestNewHealthServiceQuery(t *testing.T) {
 			"name_near",
 			"name~near",
 			&HealthServiceQuery{
-				filters: []string{"passing"},
-				name:    "name",
-				near:    "near",
+				deprecatedStatusFilters: []string{"passing"},
+				name:                    "name",
+				near:                    "near",
+				passingOnly:             true,
 			},
 			false,
 		},
@@ -86,9 +90,10 @@ func TestNewHealthServiceQuery(t *testing.T) {
 			"tag_name",
 			"tag.name",
 			&HealthServiceQuery{
-				filters: []string{"passing"},
-				name:    "name",
-				tag:     "tag",
+				deprecatedStatusFilters: []string{"passing"},
+				name:                    "name",
+				deprecatedTag:           "tag",
+				passingOnly:             true,
 			},
 			false,
 		},
@@ -96,10 +101,11 @@ func TestNewHealthServiceQuery(t *testing.T) {
 			"tag_name_dc",
 			"tag.name@dc",
 			&HealthServiceQuery{
-				dc:      "dc",
-				filters: []string{"passing"},
-				name:    "name",
-				tag:     "tag",
+				dc:                      "dc",
+				deprecatedStatusFilters: []string{"passing"},
+				name:                    "name",
+				deprecatedTag:           "tag",
+				passingOnly:             true,
 			},
 			false,
 		},
@@ -107,10 +113,11 @@ func TestNewHealthServiceQuery(t *testing.T) {
 			"tag_name_near",
 			"tag.name~near",
 			&HealthServiceQuery{
-				filters: []string{"passing"},
-				name:    "name",
-				near:    "near",
-				tag:     "tag",
+				deprecatedStatusFilters: []string{"passing"},
+				name:                    "name",
+				near:                    "near",
+				deprecatedTag:           "tag",
+				passingOnly:             true,
 			},
 			false,
 		},
@@ -118,11 +125,12 @@ func TestNewHealthServiceQuery(t *testing.T) {
 			"tag_name_dc_near",
 			"tag.name@dc~near",
 			&HealthServiceQuery{
-				dc:      "dc",
-				filters: []string{"passing"},
-				name:    "name",
-				near:    "near",
-				tag:     "tag",
+				dc:                      "dc",
+				deprecatedStatusFilters: []string{"passing"},
+				name:                    "name",
+				near:                    "near",
+				deprecatedTag:           "tag",
+				passingOnly:             true,
 			},
 			false,
 		},
@@ -153,9 +161,10 @@ func TestNewHealthServiceQuery(t *testing.T) {
 			act.stopCh = nil
 		}
 		exp := &HealthServiceQuery{
-			filters: []string{"passing"},
-			name:    "name",
-			connect: true,
+			deprecatedStatusFilters: []string{"passing"},
+			name:                    "name",
+			passingOnly:             true,
+			connect:                 true,
 		}
 
 		assert.Equal(t, exp, act)
@@ -429,6 +438,185 @@ func TestHealthServiceQuery_String(t *testing.T) {
 	for i, tc := range cases {
 		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
 			d, err := NewHealthServiceQuery(tc.i)
+			if err != nil {
+				t.Fatal(err)
+			}
+			assert.Equal(t, tc.exp, d.String())
+		})
+	}
+}
+
+func TestNewHealthServiceQueryV1(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty service name", func(t *testing.T) {
+		act, err := NewHealthServiceQueryV1("", []string{})
+		assert.Error(t, err)
+		assert.Nil(t, act)
+	})
+
+	cases := []struct {
+		name string
+		opts []string
+		exp  *HealthServiceQuery
+		err  bool
+	}{
+		{
+			"no opts",
+			[]string{},
+			&HealthServiceQuery{
+				name:        "name",
+				filter:      "Status == passing",
+				passingOnly: true,
+			},
+			false,
+		}, {
+			"dc",
+			[]string{"dc=dc"},
+			&HealthServiceQuery{
+				name:        "name",
+				dc:          "dc",
+				filter:      "Status == passing",
+				passingOnly: true,
+			},
+			false,
+		}, {
+			"near",
+			[]string{"near=near"},
+			&HealthServiceQuery{
+				name:        "name",
+				near:        "near",
+				filter:      "Status == passing",
+				passingOnly: true,
+			},
+			false,
+		}, {
+			"namespace",
+			[]string{"ns=ns"},
+			&HealthServiceQuery{
+				name:        "name",
+				ns:          "ns",
+				filter:      "Status == passing",
+				passingOnly: true,
+			},
+			false,
+		}, {
+			"multiple queries",
+			[]string{"ns=ns", "dc=dc", "near=near"},
+			&HealthServiceQuery{
+				name:        "name",
+				dc:          "dc",
+				near:        "near",
+				ns:          "ns",
+				filter:      "Status == passing",
+				passingOnly: true,
+			},
+			false,
+		}, {
+			"filters",
+			[]string{"Status != passing", "\"my-tag\" in ServiceTags"},
+			&HealthServiceQuery{
+				name:   "name",
+				filter: "Status != passing and \"my-tag\" in ServiceTags",
+			},
+			false,
+		}, {
+			"query and filter",
+			[]string{"dc=dc", "\"my-tag\" in ServiceTags", "\"another-tag\" in ServiceTags"},
+			&HealthServiceQuery{
+				name:   "name",
+				dc:     "dc",
+				filter: "\"my-tag\" in ServiceTags and \"another-tag\" in ServiceTags",
+			},
+			false,
+		}, {
+			"invalid query",
+			[]string{"dne=dne"},
+			nil,
+			true,
+		}, {
+			"invalid filter grammar",
+			[]string{"ServiceTags === tag"},
+			nil,
+			true,
+		}, {
+			"invalid filter grammar",
+			[]string{"Grammer is not empty", "Grammar is very bad"},
+			nil,
+			true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			act, err := NewHealthServiceQueryV1("name", tc.opts)
+			if tc.err {
+				assert.Error(t, err)
+				return
+			}
+
+			if act != nil {
+				act.stopCh = nil
+			}
+
+			assert.NoError(t, err, err)
+			assert.Equal(t, tc.exp, act)
+		})
+	}
+
+	// Connect
+	// all tests above also test connect, just need to check enabling it
+	t.Run("connect_query", func(t *testing.T) {
+		act, err := NewHealthConnectQueryV1("name", nil)
+		if act != nil {
+			act.stopCh = nil
+		}
+		exp := &HealthServiceQuery{
+			filter:      "Status == passing",
+			name:        "name",
+			passingOnly: true,
+			connect:     true,
+		}
+
+		assert.NoError(t, err)
+		assert.Equal(t, exp, act)
+	})
+}
+
+func TestHealthServiceQueryV1_String(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		i    []string
+		exp  string
+	}{
+		{
+			"name",
+			[]string{},
+			`health.service(name?filter="Status == passing")`,
+		}, {
+			"dc",
+			[]string{"dc=dc"},
+			`health.service(name@dc?filter="Status == passing")`,
+		}, {
+			"near",
+			[]string{"near=agent"},
+			`health.service(name~agent?filter="Status == passing")`,
+		}, {
+			"ns",
+			[]string{"ns=ns"},
+			`health.service(name?ns=ns&filter="Status == passing")`,
+		}, {
+			"multifilter",
+			[]string{"Status contains passing", "mytag in ServiceTags"},
+			`health.service(name?filter="Status contains passing and mytag in ServiceTags")`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d, err := NewHealthServiceQueryV1("name", tc.i)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/template.go
+++ b/template.go
@@ -82,7 +82,7 @@ type TemplateInput struct {
 	// functions) should return a function that matches a signature required
 	// by text/template's Funcmap (masked by an interface).
 	// This special case function's signature should match:
-	//    func(Recaller, *DepSet, *DepSet) interface{}
+	//    func(Recaller) interface{}
 	FuncMapMerge template.FuncMap
 
 	// SandboxPath adds a prefix to any path provided to the `file` function


### PR DESCRIPTION
Add a new set of template functions for Consul that adds support for querying:
* Namespaces
* Filters
* Service names with periods

Supported functions
* `service`: [`/v1/health/service/:service`](https://www.consul.io/api-docs/health#list-nodes-for-service)
* `connect`: [`/v1/health/connect/:service`](https://www.consul.io/api-docs/health#list-nodes-for-connect-capable-service)

`{{ service "app" <filter options> }}` where filter options can be in any order and support the query parameters and filters for the corresponding endpoints. Deprecated query parameters are not supported.

Template example
```
{{ service "app" "dc=dc1" "\"my-tag\" in Service.Tags" "\"another-tag\" in Service.Tags" }}
```

To use the new set of functions
```go
hcat.NewTemplate(hcat.TemplateInput{
  FuncMapMerge: hcat.FuncMapConsulV1()
})
```

Error when querying for namespace without Consul Enterprise
```
Unexpected response code: 400 (Bad request: Invalid query parameter: "ns" - Namespaces are a Consul Enterprise feature)
```

Resolves #20