### PR TITLE
Support "=" character in tag filter option

### DIFF
--- a/internal/dependency/health_service.go
+++ b/internal/dependency/health_service.go
@@ -111,15 +111,14 @@ func healthServiceQueryV1(service string, connect bool, opts []string) (*HealthS
 			switch query {
 			case "dc", "datacenter":
 				healthServiceQuery.dc = value
+				continue
 			case "ns", "namespace":
 				healthServiceQuery.ns = value
+				continue
 			case "near":
 				healthServiceQuery.near = value
-			default:
-				return nil, fmt.Errorf(
-					"health.service: invalid query parameter: %q for %q", opt, service)
+				continue
 			}
-			continue
 		}
 
 		if strings.Contains(opt, "Checks.Status") {

--- a/internal/dependency/health_service_test.go
+++ b/internal/dependency/health_service_test.go
@@ -555,6 +555,14 @@ func TestNewHealthServiceQueryV1(t *testing.T) {
 			},
 			false,
 		}, {
+			"non-DNS compliant tag filter still valid",
+			[]string{"Checks.Status != passing", `"my=tag" in Service.Tags`},
+			&HealthServiceQuery{
+				name:   "name",
+				filter: "Checks.Status != passing and \"my=tag\" in Service.Tags",
+			},
+			false,
+		}, {
 			"query and filter",
 			[]string{"dc=dc", "\"my-tag\" in Service.Tags", "\"another-tag\" in Service.Tags"},
 			&HealthServiceQuery{


### PR DESCRIPTION
Although the tag is not [DNS-compliant per Consul recommendations](https://www.consul.io/docs/discovery/services#service-and-tag-names-with-dns) it is still a valid tag to filter on. This updates hcat to be less strict on distinguishing query parameters from filter options based on the "=" separator.

The new test fails prior to change and now passes ✅ 

Error prior to changes
```
executing "73ef288bd52ec7941af460dd352923bc" at <service "my-app" "\"my=tag\" in Service.Tags">: error calling service: health.service: invalid query parameter: "\"my=tag\" in Service.Tags" for "my-app"
```

The below curl is a valid Consul API request
```
 curl --get localhost:8500/v1/health/service/api --data-urlencode 'filter="my=tag" in Service.Tags'
```