### PR TITLE
Notifiers watching the same dependency would get removed

### DIFF
--- a/watcher.go
+++ b/watcher.go
@@ -549,12 +549,16 @@ func (t *tracker) initialized(viewID string) bool {
 // ie. it returns true if all values have been fetched
 func (t *tracker) complete(n Notifier) bool {
 	for _, tp := range t.tracked {
-		thisNotifier := tp.notify == n.ID()
-		if thisNotifier && tp.inUse && !t.initialized(tp.view) {
+		if tp.notify == n.ID() {
+			if tp.inUse && t.initialized(tp.view) {
+				return true
+			}
 			return false
 		}
 	}
-	return true
+
+	// Return false if the notifier is not found
+	return false
 }
 
 // Clean out un-used trackedPair entries, views and notifiers
@@ -563,12 +567,11 @@ func (t *tracker) sweep(n Notifier) {
 	t.Lock()
 	defer t.Unlock()
 	used := make(map[string]struct{})
-	// remove tracked that were used
 	tmp := t.tracked[:0]
 	for _, tp := range t.tracked {
 		otherNotifier := tp.notify != n.ID()
 		if tp.inUse || otherNotifier {
-			tmp = append(tmp, tp.refresh())
+			tmp = append(tmp, tp)
 			used[tp.view] = struct{}{}
 			used[tp.notify] = struct{}{}
 		}
@@ -580,9 +583,9 @@ func (t *tracker) sweep(n Notifier) {
 			delete(t.views, v)
 		}
 	}
-	for n := range t.notifiers {
-		if _, ok := used[n]; !ok {
-			delete(t.views, n)
+	for notifierID := range t.notifiers {
+		if _, ok := used[notifierID]; !ok {
+			delete(t.notifiers, notifierID)
 		}
 	}
 }


### PR DESCRIPTION
Edge case where two or more templates monitored the same one dependency, once they have been initialized, sweep would end up removing the other templates.

I'm not sure what the intent behind `trackedPair.refresh()` is for or `tracker.sweep()` but the proposed changes get the above edge case to work and the added tests to pass.

Running the new tests without the changes, you can see how the second notifier get removed along with the other dependency.

Resolves https://github.com/hashicorp/consul-terraform-sync/issues/234

```
$ go test -run TestWatcherWatching
--- FAIL: TestWatcherWatching (0.00s)
    --- FAIL: TestWatcherWatching/multi-notifiers-same-dep (0.00s)
        watcher_test.go:137: unexpected number of notifiers for view: test_dep() [0xc0000ab600]
    --- FAIL: TestWatcherWatching/multi-notifiers-multi-dep (0.00s)
        watcher_test.go:200: unexpected number of notifiers for view: test_dep(taco) [0xc0000ab720]
        watcher_test.go:205: expected to be Watching after Complete: test_dep(burrito)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x14dd687]

goroutine 30 [running]:
testing.tRunner.func1.1(0x15870e0, 0x1aaf7f0)
	/usr/local/go/src/testing/testing.go:988 +0x30d
testing.tRunner.func1(0xc0000cbc20)
	/usr/local/go/src/testing/testing.go:991 +0x3f9
panic(0x15870e0, 0x1aaf7f0)
	/usr/local/go/src/runtime/panic.go:969 +0x166
github.com/hashicorp/hcat.(*view).ID(...)
	/Users/kngo/dev/hashicorp/hcat/view.go:121
github.com/hashicorp/hcat.(*tracker).notifiersFor(0xc00011b560, 0x0, 0x2a, 0xc000059f20, 0x1)
	/Users/kngo/dev/hashicorp/hcat/watcher.go:530 +0x37
github.com/hashicorp/hcat.TestWatcherWatching.func6(0xc0000cbc20)
	/Users/kngo/dev/hashicorp/hcat/watcher_test.go:207 +0x630
testing.tRunner(0xc0000cbc20, 0x16530a0)
	/usr/local/go/src/testing/testing.go:1039 +0xdc
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1090 +0x372
exit status 2
FAIL	github.com/hashicorp/hcat	0.728s
```