### PR TITLE
Notifers watching the same dependency would get removed

### DIFF
--- a/resolver_test.go
+++ b/resolver_test.go
@@ -126,8 +126,11 @@ func TestResolverRun(t *testing.T) {
 	// dep1 returns a list of words where dep2 echos each
 	t.Run("multi-pass-run", func(t *testing.T) {
 		// Changing the wait time allows hashicat to process more data in one loop
+		// and it's possible that this tests the behavior of trackedPair.refresh()
+		// which is half implemented. Skipping until that gets flushed out.
 		// TODO: This test needs to be updated to the improved process
 		t.Skip("skipping this test until it can be refactored.")
+		
 		rv := NewResolver()
 		tt := echoListTemplate(t, "foo", "bar")
 		w := blindWatcher(t)

--- a/watcher.go
+++ b/watcher.go
@@ -406,6 +406,9 @@ func (tp trackedPair) used() trackedPair {
 }
 
 // returns new pair to keep as value
+//
+// TODO: refresh tracking is not fully implemented in that dependencies are not
+// re-added after removed. This is no longer used within sweep() until then.
 func (tp trackedPair) refresh() trackedPair {
 	tp.inUse = false
 	return tp
@@ -566,6 +569,10 @@ func (t *tracker) complete(n Notifier) bool {
 
 // Clean out un-used trackedPair entries, views and notifiers
 // Checks based on passed in notifier, ignores others.
+//
+// sweep is useful to cleanup nested dependencies. This is a possible case
+// with Consul Template when the root dep no longer exists and the child dep
+// monitoring needs to be cleaned up.
 func (t *tracker) sweep(n Notifier) {
 	t.Lock()
 	defer t.Unlock()


### PR DESCRIPTION
Edge case where two or more templates monitored the same one dependency, once they have been initialized, sweep would end up removing the other templates.

I'm not sure what the intent behind `trackedPair.refresh()` is for or `tracker.sweep()` but the proposed changes get the above edge case to work and the added tests to pass.

Running the new tests without the changes, you can see how the second notifier get removed along with the other dependency.

Resolves https://github.com/hashicorp/consul-terraform-sync/issues/234

```
$ go test -run TestWatcherWatching
--- FAIL: TestWatcherWatching (0.00s)
    --- FAIL: TestWatcherWatching/multi-notifiers-same-dep (0.00s)
        watcher_test.go:137: unexpected number of notifiers for view: test_dep() [0xc0000ab600]
    --- FAIL: TestWatcherWatching/multi-notifiers-multi-dep (0.00s)
        watcher_test.go:200: unexpected number of notifiers for view: test_dep(taco) [0xc0000ab720]
        watcher_test.go:205: expected to be Watching after Complete: test_dep(burrito)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x14dd687]

goroutine 30 [running]:
testing.tRunner.func1.1(0x15870e0, 0x1aaf7f0)
	/usr/local/go/src/testing/testing.go:988 +0x30d
testing.tRunner.func1(0xc0000cbc20)
	/usr/local/go/src/testing/testing.go:991 +0x3f9
panic(0x15870e0, 0x1aaf7f0)
	/usr/local/go/src/runtime/panic.go:969 +0x166
github.com/hashicorp/hcat.(*view).ID(...)
	/Users/kngo/dev/hashicorp/hcat/view.go:121
github.com/hashicorp/hcat.(*tracker).notifiersFor(0xc00011b560, 0x0, 0x2a, 0xc000059f20, 0x1)
	/Users/kngo/dev/hashicorp/hcat/watcher.go:530 +0x37
github.com/hashicorp/hcat.TestWatcherWatching.func6(0xc0000cbc20)
	/Users/kngo/dev/hashicorp/hcat/watcher_test.go:207 +0x630
testing.tRunner(0xc0000cbc20, 0x16530a0)
	/usr/local/go/src/testing/testing.go:1039 +0xdc
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1090 +0x372
exit status 2
FAIL	github.com/hashicorp/hcat	0.728s
```