### PR TITLE
Fix identifying ConsulType and VaultType dependencies

### DIFF
--- a/internal/dependency/dependency.go
+++ b/internal/dependency/dependency.go
@@ -33,17 +33,17 @@ type BlockingQuery interface {
 	blockingQuery()
 }
 type VaultType interface {
-	isVault()
+	Vault()
 }
 type ConsulType interface {
-	isConsul()
+	Consul()
 }
 type isConsul struct{}
 type isVault struct{}
 type isBlocking struct{}
 
-func (isConsul) isConsul()        {}
-func (isVault) isVault()          {}
+func (isConsul) Consul()          {}
+func (isVault) Vault()            {}
 func (isBlocking) blockingQuery() {}
 
 // This specifies all the fields internally required by dependencies.

--- a/internal/dependency/fakedep.go
+++ b/internal/dependency/fakedep.go
@@ -12,6 +12,7 @@ import (
 ////////////
 // FakeDep is a fake dependency that does not actually speaks to a server.
 type FakeDep struct {
+	isConsul
 	Name string
 }
 

--- a/watcher_test.go
+++ b/watcher_test.go
@@ -60,6 +60,23 @@ func TestWatcherAdd(t *testing.T) {
 			// Got data, which means the poll was started
 		}
 	})
+	t.Run("consul-retry-func", func(t *testing.T) {
+		w := newWatcher(t)
+		w.retryFuncConsul = func(n int) (bool, time.Duration) {
+			return false, 0 * time.Second
+		}
+		defer w.Stop()
+
+		d := &idep.FakeDep{}
+		n := fakeNotifier("foo")
+		added := w.register(n, d)
+		if added == nil {
+			t.Fatal("Register returned nil")
+		}
+		if added.retryFunc == nil {
+			t.Fatal("Retry func was nil")
+		}
+	})
 }
 
 func TestWatcherWatching(t *testing.T) {
@@ -162,8 +179,8 @@ func TestWatcherWatching(t *testing.T) {
 		w := newWatcher(t)
 		defer w.Stop()
 
-		d0 := &idep.FakeDep{"taco"}    // dep for foo and bar
-		d1 := &idep.FakeDep{"burrito"} // dep for bar
+		d0 := &idep.FakeDep{Name: "taco"}    // dep for foo and bar
+		d1 := &idep.FakeDep{Name: "burrito"} // dep for bar
 		nFoo := fakeNotifier("foo")
 		nBar := fakeNotifier("bar")
 		w.Register(nFoo, d0)


### PR DESCRIPTION
In watcher.register(), dependencies (d) were not being identified as ConsulType
and VaultType as expected when switching on type:

```
switch d.(type) {
case idep.ConsulType:
	retryFunc = w.retryFuncConsul
case idep.VaultType:
	retryFunc = w.retryFuncVault
}
```

Dependencies have nested structs (isConsul or isVault) which implement
ConsulType and VaultType interfaces. However, the isConsul and isVault structs
use methods with the same name to satisfy interfaces. This same name causes
diverging access to the method.

For example:
```
type isConsul struct{}
func (isConsul) isConsul() {}

type HealthService struct {isConsul}

func main() {
	hs := HealthService{}
	hs.isConsul()
}
```

Here hs.isConsul() will throw an error "non-function hs.isConsul (type isConsul)".
In order to access isConsul(), we would need to use `hs.isConsul.isConsul()`.

This special behavior caused the type assertion to not identify dependencies
(such as HealthService in the example) to be identified as ConsulType.

Change: rename method to be different from struct to avoid confusion.
isConsul() => Consul(). This makes allows access to the method in this way:
`hs.Consul()`