### PR TITLE
Reset cached Consul Index to zero when Consul restarts

### DIFF
--- a/internal/dependency/fakedep.go
+++ b/internal/dependency/fakedep.go
@@ -102,7 +102,7 @@ type FakeDepFetchError struct {
 
 func (d *FakeDepFetchError) Fetch(dep.Clients) (interface{}, *dep.ResponseMetadata, error) {
 	time.Sleep(time.Microsecond)
-	return nil, nil, fmt.Errorf("failed to contact server")
+	return nil, nil, fmt.Errorf("failed to contact server: connection refused")
 }
 
 func (d *FakeDepFetchError) CanShare() bool {


### PR DESCRIPTION
When hcat loses connection with Consul (e.g. Consul is stopped for whatever
reason), `view.fetch()` may send an error to fetchErrCh such as:

```Get "http://localhost:8500/v1/health/service/api?filter=Checks.Status+%3D%3D+%22passing%22&index=12": dial tcp 127.0.0.1:8500: connect: connection refused```

For connection refused errors, reset the stored lastIndex to zero. When
Consul restarts, this prevents hcat from using a stale lastIndex (which causes
hanging) and allows hcat to quickly retrieve the latest lastIndex
