### PR TITLE
register-complete race issue

### DIFF
--- a/store.go
+++ b/store.go
@@ -42,7 +42,7 @@ func (s *Store) Recall(id string) (interface{}, bool) {
 }
 
 // Forget accepts a dependency and removes all associated data with this
-// dependency. It also resets the "receivedData" internal map.
+// dependency.
 func (s *Store) Delete(id string) {
 	s.Lock()
 	defer s.Unlock()

--- a/template_test.go
+++ b/template_test.go
@@ -717,6 +717,8 @@ type fakeWatcher struct {
 
 func (fakeWatcher) Buffer(string) bool       { return false }
 func (f fakeWatcher) Complete(Notifier) bool { return true }
+func (f fakeWatcher) Mark(Notifier)          {}
+func (f fakeWatcher) Sweep(Notifier)         {}
 func (f fakeWatcher) Recaller(Notifier) Recaller {
 	return func(d dep.Dependency) (value interface{}, found bool) {
 		return f.Store.Recall(d.String())

--- a/watcher.go
+++ b/watcher.go
@@ -469,17 +469,6 @@ func (t *tracker) viewCount() int {
 	return len(t.views)
 }
 
-// notUsed clears the inUse flag, for testing
-func (t *tracker) notUsed(notifierID, viewID string) bool {
-	for i, tp := range t.tracked {
-		if tp.view == viewID && tp.notify == notifierID {
-			t.tracked[i] = tp.refresh()
-			return true
-		}
-	}
-	return false
-}
-
 // lookup returns the view and true, or nil and false
 // true is returned if the notifier and depencency match a tracked pair
 // returns the view as it is the 1 thing that you don't have yet
@@ -573,14 +562,6 @@ func (t *tracker) notifiersFor(v *view) []Notifier {
 	return results
 }
 
-// initialized returns true if the view has had its data fetched at least once
-func (t *tracker) initialized(viewID string) bool {
-	if v, ok := t.views[viewID]; ok {
-		return v.receivedData
-	}
-	return false
-}
-
 // complete returns true if every dependency used has been initialized
 // ie. it returns true if all values have been fetched
 func (t *tracker) complete(n Notifier) bool {
@@ -650,13 +631,4 @@ func (n *dummyNotifier) ID() string {
 }
 func (n *dummyNotifier) count() int {
 	return len(n.deps)
-}
-func (n *dummyNotifier) ids() []string {
-	results := make([]string, len(n.deps))
-	for i := 0; i < len(n.deps); i++ {
-		d := <-n.deps
-		results[i] = d.String()
-		n.deps <- d
-	}
-	return results
 }

--- a/watcher.go
+++ b/watcher.go
@@ -193,10 +193,7 @@ func (w *Watcher) Wait(ctx context.Context) error {
 				select {
 				case view := <-w.dataCh:
 					dataUpdate(view)
-				case <-time.After(time.Second):
-					// 1 second is a high value used as as temporary workaround
-					// to mitigate the initial flood of data on the first run
-					// before the template rendering races with unprocessed data.
+				case <-time.After(time.Microsecond):
 					return nil
 				}
 			}

--- a/watcher_test.go
+++ b/watcher_test.go
@@ -385,7 +385,7 @@ func TestWatcherWait(t *testing.T) {
 		if err != nil {
 			t.Fatal("Error not expected")
 		}
-		dur := time.Now().Sub(t1)
+		dur := time.Since(t1)
 		if dur < time.Microsecond*100 || dur > time.Millisecond*10 {
 			t.Fatal("Wait call was off;", dur)
 		}
@@ -401,7 +401,7 @@ func TestWatcherWait(t *testing.T) {
 		if err != nil {
 			t.Fatal("Error not expected")
 		}
-		dur := time.Now().Sub(t1)
+		dur := time.Since(t1)
 		if dur < time.Microsecond*100 || dur > time.Millisecond*10 {
 			t.Fatal("Wait call was off;", dur)
 		}
@@ -437,7 +437,7 @@ func TestWatcherWait(t *testing.T) {
 			w.errCh <- testerr
 		}()
 		w.Wait(context.Background())
-		dur := time.Now().Sub(t1)
+		dur := time.Since(t1)
 		if dur < time.Microsecond*100 || dur > time.Millisecond*10 {
 			t.Fatal("Wait call was off;", dur)
 		}
@@ -538,7 +538,6 @@ func TestWatcherWait(t *testing.T) {
 		for i := 0; i < 2; i++ {
 			foodep := &idep.FakeDep{Name: "foo"}
 			w.dataCh <- w.register(n, foodep)
-			//w.dataCh <- w.tracker.views[foodep.String()]
 		}
 		w.Wait(context.Background())
 		if n.count() != 2 {
@@ -572,10 +571,7 @@ func TestWatcherWait(t *testing.T) {
 		errCh := make(chan error)
 		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
 		go func() {
-			select {
-			case err := <-w.WaitCh(ctx):
-				errCh <- err
-			}
+			errCh <- <-w.WaitCh(ctx)
 		}()
 		cancel()
 		err := <-errCh


### PR DESCRIPTION
This patch does 2 things.
1. track first use of data for completeness checks
2. view/dep usage tracking and unused collection

I broke up the commits as best I could to help make sense of the changes with separate commits for the data use tracking (1) and the view/dep use tracking (2). There are also separate commits for the initial issue test case, reverting the 1 second time temp fix, and some dead code removal and linter fixes.

Fixes #44 