### PR TITLE
Add v1 `services` template function for Catalog List Services API

### DIFF
--- a/consul_v1.go
+++ b/consul_v1.go
@@ -15,15 +15,15 @@ var errFuncNotImplemented = fmt.Errorf("function is not implemented")
 // namespaces.
 func FuncMapConsulV1() template.FuncMap {
 	return template.FuncMap{
-		"service": v1ServiceFunc,
-		"connect": v1ConnectFunc,
+		"service":  v1ServiceFunc,
+		"connect":  v1ConnectFunc,
+		"services": v1ServicesFunc,
 
 		// Set of Consul functions that are not yet implemented for v1. These
 		// intentionally error instead of defaulting to the v0 implementations
 		// to avoid introducing breaking changes when they are supported.
-		"node":     v1TODOFunc,
-		"nodes":    v1TODOFunc,
-		"services": v1TODOFunc,
+		"node":  v1TODOFunc,
+		"nodes": v1TODOFunc,
 	}
 }
 
@@ -32,6 +32,27 @@ func FuncMapConsulV1() template.FuncMap {
 func v1TODOFunc(recall Recaller) interface{} {
 	return func(s ...string) (interface{}, error) {
 		return nil, errFuncNotImplemented
+	}
+}
+
+// v1ServicesFunc returns information on registered Consul services
+//
+// Endpoint: /v1/catalog/services
+// Template: {{ services <filter options> ... }}
+func v1ServicesFunc(recall Recaller) interface{} {
+	return func(opts ...string) ([]*dep.CatalogSnippet, error) {
+		result := []*dep.CatalogSnippet{}
+
+		d, err := idep.NewCatalogServicesQueryV1(opts)
+		if err != nil {
+			return nil, err
+		}
+
+		if value, ok := recall(d); ok {
+			return value.([]*dep.CatalogSnippet), nil
+		}
+
+		return result, nil
 	}
 }
 

--- a/consul_v1_test.go
+++ b/consul_v1_test.go
@@ -93,9 +93,26 @@ func TestTemplateExecute_consul_v1(t *testing.T) {
 			TemplateInput{
 				Contents: `{{ range services }}{{ .Name }}{{ end }}`,
 			},
-			nil,
-			"",
-			true,
+			func() *Store {
+				st := NewStore()
+				d, err := idep.NewCatalogServicesQueryV1([]string{})
+				if err != nil {
+					t.Fatal(err)
+				}
+				st.Save(d.String(), []*dep.CatalogSnippet{
+					{
+						Name: "web",
+						Tags: dep.ServiceTags([]string{"tag1", "tag2"}),
+					},
+					{
+						Name: "api",
+						Tags: dep.ServiceTags([]string{"tag3"}),
+					},
+				})
+				return st
+			}(),
+			"webapi",
+			false,
 		}, {
 			"func_datacenters_v0",
 			TemplateInput{

--- a/internal/dependency/catalog_services.go
+++ b/internal/dependency/catalog_services.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"regexp"
 	"sort"
+	"strings"
 
 	"github.com/hashicorp/hcat/dep"
 	"github.com/pkg/errors"
@@ -30,6 +31,37 @@ type CatalogServicesQuery struct {
 
 	dc   string
 	opts QueryOptions
+}
+
+// NewCatalogServicesQueryV1 processes options in the format of "key=value"
+// e.g. "dc=dc1"
+func NewCatalogServicesQueryV1(opts []string) (*CatalogServicesQuery, error) {
+	catalogServicesQuery := CatalogServicesQuery{
+		stopCh: make(chan struct{}, 1),
+	}
+
+	for _, opt := range opts {
+		if strings.TrimSpace(opt) == "" {
+			continue
+		}
+
+		queryParam := strings.Split(opt, "=")
+		if len(queryParam) != 2 {
+			return nil, fmt.Errorf(
+				"catalog.services: invalid query parameter format: %q", opt)
+		}
+		query := strings.TrimSpace(queryParam[0])
+		value := strings.TrimSpace(queryParam[1])
+		switch query {
+		case "dc", "datacenter":
+			catalogServicesQuery.dc = value
+		default:
+			return nil, fmt.Errorf(
+				"catalog.services: invalid query parameter: %q", opt)
+		}
+	}
+
+	return &catalogServicesQuery, nil
 }
 
 // NewCatalogServicesQuery parses a string of the format @dc.

--- a/internal/dependency/catalog_services_test.go
+++ b/internal/dependency/catalog_services_test.go
@@ -55,6 +55,61 @@ func TestNewCatalogServicesQuery(t *testing.T) {
 	}
 }
 
+func TestNewCatalogServicesQueryV1(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		opts []string
+		exp  *CatalogServicesQuery
+		err  bool
+	}{
+		{
+			"no opts",
+			[]string{},
+			&CatalogServicesQuery{},
+			false,
+		},
+		{
+			"dc",
+			[]string{"dc=dc1"},
+			&CatalogServicesQuery{
+				dc: "dc1",
+			},
+			false,
+		},
+		{
+			"invalid query",
+			[]string{"invalid=true"},
+			nil,
+			true,
+		},
+		{
+			"invalid query format",
+			[]string{"dc1"},
+			nil,
+			true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			act, err := NewCatalogServicesQueryV1(tc.opts)
+			if tc.err {
+				assert.Error(t, err)
+				return
+			}
+
+			if act != nil {
+				act.stopCh = nil
+			}
+
+			assert.NoError(t, err, err)
+			assert.Equal(t, tc.exp, act)
+		})
+	}
+}
+
 func TestCatalogServicesQuery_Fetch(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Previously, we upgraded Consul template functions to v1 to add more support for
querying https://github.com/hashicorp/hcat/pull/35

This PR updates to v1 the `services` template function that is used to query Catalog
List Services API: `/v1/catalog/services`

Template: `{{ services <filter options> }}` where filter options can be in any
order and support query parameters for the Catalog List Services API

Template usage example: `{{ services "dc=dc1"}}`

Currently, the only filter option supported is Datacenter (in order to maintain
parity with the "v0" template). In future changes, we will add additional support
for querying by namespaces and node-meta.