### PR TITLE
Notifier interface gets new Notify() signature

### DIFF
--- a/template.go
+++ b/template.go
@@ -134,11 +134,12 @@ func (t *Template) ID() string {
 }
 
 // Notify template that a dependency it relies on has been updated.
-func (t *Template) Notify(dep.Dependency) {
+func (t *Template) Notify(interface{}) bool {
 	select {
 	case t.dirty <- struct{}{}:
 	default:
 	}
+	return true
 }
 
 // Check and clear dirty flag


### PR DESCRIPTION
Updates the Notifier interface, and the implementations, with the new
version of the Notify() method signature. The new version takes the
newly updated data as the argument and returns a boolean that determines
if Wait() returns or continues to wait. This, along with how it calls
the existing template or otherwise manages notification updates, gives
the Notify() implementor control over whether that update triggers a
action (like template rendering) in the applications.

The old method signature was mostly a placeholder, so this is the first
complete version of the interface.