### PR TITLE
Watcher updates

### DIFF
--- a/watcher.go
+++ b/watcher.go
@@ -330,7 +330,7 @@ func (w *Watcher) Mark(n Notifier) {
 
 // Stop and dereference all views for dependencies still marked as *not* in use.
 func (w *Watcher) Sweep(n Notifier) {
-	w.tracker.sweep(n)
+	w.tracker.sweep(n, w.cache)
 }
 
 // SetBufferPeriod sets a buffer period to accumulate dependency changes for
@@ -562,7 +562,7 @@ func (t *tracker) mark(n Notifier) {
 // sweep (delete) unused pairs and views. It stops views before deleting their
 // reference.
 // Notifiers are not handled as they aren't internal objects.
-func (t *tracker) sweep(n Notifier) {
+func (t *tracker) sweep(n Notifier, cache Cacher) {
 	t.Lock()
 	defer t.Unlock()
 	used := make(map[string]struct{})
@@ -581,6 +581,7 @@ func (t *tracker) sweep(n Notifier) {
 		if _, ok := used[viewId]; !ok {
 			delete(t.views, viewId)
 			view.stop()
+			cache.Delete(viewId)
 		}
 	}
 }

--- a/watcher.go
+++ b/watcher.go
@@ -368,17 +368,6 @@ func (w *Watcher) Size() int {
 	return w.tracker.viewCount()
 }
 
-// Remove-s the given dependency from the list and stops the
-// associated view. If a view for the given dependency does not exist, this
-// function will return false. If the view does exist, this function will return
-// true upon successful deletion.
-func (w *Watcher) remove(id string) bool {
-	//log.Printf("[DEBUG] (watcher) removing %s", id)
-
-	defer w.cache.Delete(id)
-	return w.tracker.remove(id)
-}
-
 // Watching determines if the given dependency (id) is being watched.
 func (w *Watcher) Watching(id string) bool {
 	v := w.tracker.view(id)
@@ -517,24 +506,6 @@ func (t *tracker) inUse(n Notifier, d dep.Dependency) {
 			t.tracked[i] = tp.markInUse()
 		}
 	}
-}
-
-// Remove view and all trackedPairs that contained it
-func (t *tracker) remove(viewID string) bool {
-	t.Lock()
-	defer t.Unlock()
-	delete(t.views, viewID)
-	tmp := t.tracked[:0]
-	var removed bool
-	for _, tp := range t.tracked {
-		if tp.view != viewID {
-			tmp = append(tmp, tp)
-		} else {
-			removed = true
-		}
-	}
-	t.tracked = tmp
-	return removed
 }
 
 // stop all view from polling/watching

--- a/watcher_test.go
+++ b/watcher_test.go
@@ -273,37 +273,6 @@ func TestWatcherWatching(t *testing.T) {
 	})
 }
 
-func TestWatcherRemove(t *testing.T) {
-	t.Run("exists", func(t *testing.T) {
-		w := newWatcher(t)
-		defer w.Stop()
-
-		d := &idep.FakeDep{Name: "foo"}
-		n := fakeNotifier("foo")
-		w.Register(n, d)
-
-		removed := w.remove(d.String())
-		if removed != true {
-			t.Error("expected Remove to return true")
-		}
-
-		if w.Watching(d.String()) {
-			t.Error("expected dependency to be removed")
-		}
-	})
-
-	t.Run("does-not-exist", func(t *testing.T) {
-		w := newWatcher(t)
-		defer w.Stop()
-
-		var fd idep.FakeDep
-		removed := w.remove(fd.String())
-		if removed != false {
-			t.Fatal("expected Remove to return false")
-		}
-	})
-}
-
 func TestWatcherVaultToken(t *testing.T) {
 	t.Run("empty-token", func(t *testing.T) {
 		w := newWatcher(t)


### PR DESCRIPTION
3 tweaks not tied to a feature but wanted to get cleaned up.  Each of the 3 things has it's own commit to make them easier to digest.

Remove unused watcher.Remove and supporting code.
Clear cache entry during sweep step.
refine parameter type requirements, Notifier->IDer