### PR TITLE
Allow for conditional notifications with new Notify API

### DIFF
--- a/consul_v1_test.go
+++ b/consul_v1_test.go
@@ -138,7 +138,7 @@ func TestTemplateExecute_consul_v1(t *testing.T) {
 			tpl := NewTemplate(tc.ti)
 
 			w := fakeWatcher{tc.i}
-			a, err := tpl.Execute(w)
+			a, err := tpl.Execute(w.Recaller(tpl))
 			if tc.err {
 				assert.Error(t, err, "expected: funcNotImplementedError")
 				assert.Contains(t, err.Error(), errFuncNotImplemented.Error())

--- a/dep/template_function_types.go
+++ b/dep/template_function_types.go
@@ -63,6 +63,9 @@ type HealthService struct {
 	Namespace           string
 }
 
+// KvValue is here to type the KV return string
+type KvValue string
+
 // KeyPair is a simple Key-Value pair
 type KeyPair struct {
 	Path  string

--- a/doc_test.go
+++ b/doc_test.go
@@ -6,6 +6,9 @@ import (
 	"log"
 	"strings"
 	"time"
+
+	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/hcat/dep"
 )
 
 // These examples requires a running consul to test against.
@@ -16,6 +19,7 @@ const (
 		"service {{.Name }} at {{.Address}}" +
 		"{{end}}{{end}}"
 	exampleNodeTemplate = "{{range nodes}}node at {{.Address}}{{end}}"
+	exampleKvTrigger    = `{{if keyExists "notify"}}{{end}}`
 )
 
 var examples = []string{exampleServiceTemplate, exampleNodeTemplate}
@@ -23,12 +27,10 @@ var examples = []string{exampleServiceTemplate, exampleNodeTemplate}
 // Repeatedly runs the resolver on the template and watcher until the returned
 // ResolveEvent shows the template has fetched all values and completed, then
 // returns the output.
-func RenderExampleOnce(addr string) string {
+func RenderExampleOnce(clients *ClientSet) string {
 	tmpl := NewTemplate(TemplateInput{
 		Contents: exampleServiceTemplate,
 	})
-	clients := NewClientSet()
-	clients.AddConsul(ConsulInput{Address: addr})
 	w := NewWatcher(WatcherInput{
 		Clients: clients,
 		Cache:   NewStore(),
@@ -55,20 +57,16 @@ func RenderExampleOnce(addr string) string {
 // Runs the resolver over multiple templates until all have completed.
 // By looping over all the templates it can start the data lookups in each and
 // better share cached results for faster overall template rendering.
-func RenderMultipleOnce(addr string) string {
+func RenderMultipleOnce(clients *ClientSet) string {
 	templates := make([]*Template, len(examples))
 	for i, egs := range examples {
 		templates[i] = NewTemplate(TemplateInput{Contents: egs})
 	}
-	clients := NewClientSet()
-	clients.AddConsul(ConsulInput{Address: addr})
 	w := NewWatcher(WatcherInput{
 		Clients: clients,
 		Cache:   NewStore(),
 	})
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
 	results := []string{}
 	r := NewResolver()
 	for {
@@ -85,6 +83,7 @@ func RenderMultipleOnce(addr string) string {
 			break
 		}
 		// Wait pauses until new data has been received
+		ctx := context.Background()
 		err := w.Wait(ctx)
 		if err != nil {
 			log.Fatal(err)
@@ -93,20 +92,89 @@ func RenderMultipleOnce(addr string) string {
 	return strings.Join(results, ", ")
 }
 
+// An example of how you might implement a different notification strategy
+// using a custom Notifier. In this case we are wrapping a standard template
+// to have it only trigger notifications and be ready to be updated *only if*
+// the KV value 'notify' is written to.
+func NotifierExample(clients *ClientSet) string {
+	tmpl := KvNotifier{NewTemplate(TemplateInput{
+		Contents: exampleNodeTemplate + exampleKvTrigger,
+	})}
+
+	w := NewWatcher(WatcherInput{
+		Clients: clients,
+		Cache:   NewStore(),
+	})
+
+	// post KV trigger after a brief pause
+	// you'd probably do this via another means
+	go func() {
+		time.Sleep(time.Millisecond)
+		_, err := clients.Consul().KV().Put(
+			&api.KVPair{Key: "notify", Value: []byte("run")}, nil)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}()
+
+	r := NewResolver()
+	for {
+		re, err := r.Run(tmpl, w)
+		if err != nil {
+			log.Fatal(err)
+		}
+		if re.Complete {
+			return string(re.Contents)
+		}
+		// Wait pauses until new data has been received
+		if err := w.Wait(context.Background()); err != nil {
+			log.Fatal(err)
+		}
+	}
+}
+
+// Embed template to allow overridding of Notify
+type KvNotifier struct {
+	*Template
+}
+
+// Notify receives the updated value as the argument. You can then use the
+// template function types published in ./dep/template_function_types.go to
+// assert the types and notify based on the type and/or values.
+// Note calling Template's Notify() is needed to mark it as having new data.
+func (n KvNotifier) Notify(d interface{}) (notify bool) {
+	switch d.(type) {
+	case dep.KvValue:
+		n.Template.Notify(d)
+		return true
+	default:
+		return false
+	}
+}
+
 // Shows multiple examples of usage from a high level perspective.
 func Example() {
 	if *runExamples {
+		clients := NewClientSet()
+		defer clients.Stop()
 		// consuladdr is set in TestMain
-		fmt.Printf("RenderExampleOnce: %s\nRenderMultipleOnce: %s\n",
-			RenderExampleOnce(consuladdr),
-			RenderMultipleOnce(consuladdr))
+		clients.AddConsul(ConsulInput{Address: consuladdr})
+
+		fmt.Printf("RenderExampleOnce: %s\n",
+			RenderExampleOnce(clients))
+		fmt.Printf("RenderMultipleOnce: %s\n",
+			RenderMultipleOnce(clients))
+		fmt.Printf("NotifierExample: %s\n",
+			NotifierExample(clients))
 	} else {
 		// so test doesn't fail when skipping
-		fmt.Printf("RenderExampleOnce: %s\nRenderMultipleOnce: %s\n",
-			"service consul at 127.0.0.1",
+		fmt.Printf("RenderExampleOnce: %s\n", "service consul at 127.0.0.1")
+		fmt.Printf("RenderMultipleOnce: %s\n",
 			"node at 127.0.0.1, service consul at 127.0.0.1")
+		fmt.Printf("NotifierExample: node at 127.0.0.1\n")
 	}
 	// Output:
 	// RenderExampleOnce: service consul at 127.0.0.1
 	// RenderMultipleOnce: node at 127.0.0.1, service consul at 127.0.0.1
+	// NotifierExample: node at 127.0.0.1
 }

--- a/internal/dependency/kv_get.go
+++ b/internal/dependency/kv_get.go
@@ -101,7 +101,7 @@ func (d *KVGetQuery) Fetch(clients dep.Clients) (interface{}, *dep.ResponseMetad
 		return nil, rm, nil
 	}
 
-	value := string(pair.Value)
+	value := dep.KvValue(pair.Value)
 	//log.Printf("[TRACE] %s: returned %q", d, value)
 	return value, rm, nil
 }

--- a/internal/dependency/kv_get_test.go
+++ b/internal/dependency/kv_get_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/hcat/dep"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -194,12 +195,12 @@ func TestKVGetQuery_Fetch(t *testing.T) {
 		{
 			"exists",
 			"test-kv-get/key",
-			"value",
+			dep.KvValue("value"),
 		},
 		{
 			"exists_empty_string",
 			"test-kv-get/key_empty",
-			"",
+			dep.KvValue(""),
 		},
 		{
 			"no_exist",
@@ -293,7 +294,7 @@ func TestKVGetQuery_Fetch(t *testing.T) {
 		case err := <-errCh:
 			t.Fatal(err)
 		case data := <-dataCh:
-			assert.Equal(t, data, "new-value")
+			assert.Equal(t, data, dep.KvValue("new-value"))
 		}
 	})
 }

--- a/template_funcs.go
+++ b/template_funcs.go
@@ -63,10 +63,14 @@ func keyFunc(recall Recaller) func(string) (string, error) {
 		}
 
 		if value, ok := recall(d); ok {
-			if value == nil {
+			switch v := value.(type) {
+			case nil:
 				return "", nil
+			case string:
+				return v, nil
+			case dep.KvValue:
+				return string(v), nil
 			}
-			return value.(string), nil
 		}
 
 		return "", nil

--- a/template_test.go
+++ b/template_test.go
@@ -700,7 +700,7 @@ func TestTemplate_Execute(t *testing.T) {
 			tpl := NewTemplate(tc.ti)
 
 			w := fakeWatcher{tc.i}
-			a, err := tpl.Execute(w)
+			a, err := tpl.Execute(w.Recaller(tpl))
 			if (err != nil) != tc.err {
 				t.Fatal(err)
 			}

--- a/tfunc/consul_test.go
+++ b/tfunc/consul_test.go
@@ -185,7 +185,7 @@ func TestConsulExecute(t *testing.T) {
 		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
 			tpl := NewTemplate(tc.ti)
 
-			a, err := tpl.Execute(tc.i)
+			a, err := tpl.Execute(tc.i.Recaller(tpl))
 			if (err != nil) != tc.err {
 				t.Fatal(err)
 			}

--- a/tfunc/contains_test.go
+++ b/tfunc/contains_test.go
@@ -232,7 +232,7 @@ func TestContainsExecute(t *testing.T) {
 		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
 			tpl := NewTemplate(tc.ti)
 
-			a, err := tpl.Execute(tc.i)
+			a, err := tpl.Execute(tc.i.Recaller(tpl))
 			if (err != nil) != tc.err {
 				t.Fatal(err)
 			}

--- a/tfunc/env_test.go
+++ b/tfunc/env_test.go
@@ -41,7 +41,7 @@ func TestEnvExecute(t *testing.T) {
 		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
 			tpl := NewTemplate(tc.ti)
 
-			a, err := tpl.Execute(tc.i)
+			a, err := tpl.Execute(tc.i.Recaller(tpl))
 			if (err != nil) != tc.err {
 				t.Fatal(err)
 			}

--- a/tfunc/explode_test.go
+++ b/tfunc/explode_test.go
@@ -61,7 +61,7 @@ func TestExplodeExecute(t *testing.T) {
 		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
 			tpl := NewTemplate(tc.ti)
 
-			a, err := tpl.Execute(tc.i)
+			a, err := tpl.Execute(tc.i.Recaller(tpl))
 			if (err != nil) != tc.err {
 				t.Fatal(err)
 			}

--- a/tfunc/loop_test.go
+++ b/tfunc/loop_test.go
@@ -80,7 +80,7 @@ func TestLoopExecute(t *testing.T) {
 		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
 			tpl := NewTemplate(tc.ti)
 
-			a, err := tpl.Execute(tc.i)
+			a, err := tpl.Execute(tc.i.Recaller(tpl))
 			if (err != nil) != tc.err {
 				t.Fatal(err)
 			}

--- a/tfunc/math_test.go
+++ b/tfunc/math_test.go
@@ -87,7 +87,7 @@ func TestMathExecute(t *testing.T) {
 		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
 			tpl := NewTemplate(tc.ti)
 
-			a, err := tpl.Execute(tc.i)
+			a, err := tpl.Execute(tc.i.Recaller(tpl))
 			if (err != nil) != tc.err {
 				t.Fatal(err)
 			}

--- a/tfunc/parse_test.go
+++ b/tfunc/parse_test.go
@@ -96,7 +96,7 @@ func TestParseExecute(t *testing.T) {
 		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
 			tpl := NewTemplate(tc.ti)
 
-			a, err := tpl.Execute(tc.i)
+			a, err := tpl.Execute(tc.i.Recaller(tpl))
 			if (err != nil) != tc.err {
 				t.Fatal(err)
 			}

--- a/tfunc/sockaddr_test.go
+++ b/tfunc/sockaddr_test.go
@@ -23,7 +23,7 @@ func TestSockAddrExecute(t *testing.T) {
 		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
 			tpl := NewTemplate(tc.ti)
 
-			a, err := tpl.Execute(tc.i)
+			a, err := tpl.Execute(tc.i.Recaller(tpl))
 			if (err != nil) != tc.err {
 				t.Fatal(err)
 			}

--- a/tfunc/string_test.go
+++ b/tfunc/string_test.go
@@ -105,7 +105,7 @@ func TestStringExecute(t *testing.T) {
 		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
 			tpl := NewTemplate(tc.ti)
 
-			a, err := tpl.Execute(tc.i)
+			a, err := tpl.Execute(tc.i.Recaller(tpl))
 			if (err != nil) != tc.err {
 				t.Fatal(err)
 			}

--- a/tfunc/time_test.go
+++ b/tfunc/time_test.go
@@ -46,7 +46,7 @@ func TestTimeExecute(t *testing.T) {
 		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
 			tpl := NewTemplate(tc.ti)
 
-			a, err := tpl.Execute(tc.i)
+			a, err := tpl.Execute(tc.i.Recaller(tpl))
 			if (err != nil) != tc.err {
 				t.Fatal(err)
 			}

--- a/tfunc/transform_test.go
+++ b/tfunc/transform_test.go
@@ -132,7 +132,7 @@ func TestTransformExecute(t *testing.T) {
 		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
 			tpl := NewTemplate(tc.ti)
 
-			a, err := tpl.Execute(tc.i)
+			a, err := tpl.Execute(tc.i.Recaller(tpl))
 			if (err != nil) != tc.err {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
Updates the Notifier interface, and the implementations, with the new version of the Notify() method signature. The new version takes the newly updated data as the argument and returns a boolean that determines if Wait() returns or continues to wait. This, along with how it calls the existing template or otherwise manages notification updates, gives the Notify() implementer control over whether that update triggers an action (like template rendering) in the applications.

Fixes #27