### PR TITLE
Update resolver.Run return for ErrNoNewValues

### DIFF
--- a/resolver.go
+++ b/resolver.go
@@ -15,6 +15,10 @@ type ResolveEvent struct {
 	// Only returned when Complete is true.
 	Contents []byte
 
+	// NoChange is true if no dependencies have changes in values and therefore
+	// templates were not re-rendered.
+	NoChange bool
+
 	// for testing, need way to test for missing dependencies case
 	missing bool
 }
@@ -72,7 +76,7 @@ func (r *Resolver) Run(tmpl Templater, w Watcherer) (ResolveEvent, error) {
 
 	switch { // specific to general
 	case err == ErrNoNewValues:
-		return ResolveEvent{}, nil
+		return ResolveEvent{NoChange: true}, nil
 	case !w.Complete(tmpl):
 		return ResolveEvent{missing: true}, nil
 	case err == nil:

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -27,7 +27,7 @@ func TestResolverRun(t *testing.T) {
 		}
 	})
 
-	t.Run("skip-dueto-no-changes", func(t *testing.T) {
+	t.Run("no-changes", func(t *testing.T) {
 		rv := NewResolver()
 		tt := fooTemplate(t)
 		tt.isDirty() // flush dirty mark set on new templates
@@ -52,12 +52,15 @@ func TestResolverRun(t *testing.T) {
 		if string(r.Contents) != "" {
 			t.Fatal("bad contents")
 		}
+		if r.NoChange != true {
+			t.Fatal("NoChange should be true")
+		}
 		if r.missing == true {
 			t.Fatal("missing should be false")
 		}
 	})
 
-	t.Run("complete", func(t *testing.T) {
+	t.Run("complete-changes", func(t *testing.T) {
 		rv := NewResolver()
 		tt := fooTemplate(t)
 		w := blindWatcher(t)
@@ -83,6 +86,9 @@ func TestResolverRun(t *testing.T) {
 		}
 		if string(r.Contents) != "bar" {
 			t.Fatal("bad contents")
+		}
+		if r.NoChange != false {
+			t.Fatal("NoChange should be false")
 		}
 		if r.missing == true {
 			t.Fatal("missing should be false")
@@ -116,6 +122,9 @@ func TestResolverRun(t *testing.T) {
 		}
 		if r.Complete == false {
 			t.Fatal("Complete should be true")
+		}
+		if r.NoChange != false {
+			t.Fatal("NoChange should be false")
 		}
 		if string(r.Contents) != "foo" {
 			t.Fatal("Wrong contents:", string(r.Contents))
@@ -171,6 +180,9 @@ func TestResolverRun(t *testing.T) {
 		}
 		if r.Complete == false {
 			t.Fatal("Complete should be true")
+		}
+		if r.NoChange != false {
+			t.Fatal("NoChange should be false")
 		}
 		if string(r.Contents) != "foobar" {
 			t.Fatal("Wrong contents:", string(r.Contents))


### PR DESCRIPTION
In CTS, there is a need to identify when resolver.Run has no new values. There
is a use-case when a disabled task is re-enabled, we must force rendering and
task's template in case any dependency changes have occurred while the task was
disabled.

In terms of hcat, this means that for an existing template we will need to call
resolver.Run() and then template.Render() on complete. For example:

```
for i := int64(0); ; i++ {
  if result, err = tf.resolver.Run(tf.template, tf.watcher); err != nil {
    ...
    return err
  }
  if result.Complete {
    if _, err = tf.template.Render(result.Contents); err != nil {
      ...
      return err
    }
    break
  }
}
```

When called, the above pattern works fine if there have been dependency changes.
However, if there have been _no_ dependency changes, then the pattern will loop
forever. Hence the need to distinguish when dependencies have not changed.

Solution: add a new attribute and return  ResolveEvent{NoChange: true} to
distinguish when no dependencies have changed.

Prior solution: return ResolveEvent{Complete: true, Content: []byte{}}. This
does not work since Content == []byte{} is a possible valid template render.

Not sure if this is the best solution. Opened this PR as the easiest way to
describe the situation and start the discussion. Feedback welcome!