### PR TITLE
explicit registering of notifiers with watcher

### DIFF
--- a/resolver.go
+++ b/resolver.go
@@ -28,7 +28,7 @@ func NewResolver() *Resolver {
 // Watcherer is the subset of the Watcher's API that the resolver needs.
 // The interface is used to make the used/required API explicit.
 type Watcherer interface {
-	Buffer(tmplID string) bool
+	Buffer(Notifier) bool
 	Recaller(Notifier) Recaller
 	Complete(Notifier) bool
 }
@@ -47,7 +47,7 @@ func (r *Resolver) Run(tmpl Templater, w Watcherer) (ResolveEvent, error) {
 
 	// Check if this dependency has any dependencies that have been change and
 	// if not, don't waste time re-rendering it.
-	if w.Buffer(tmpl.ID()) {
+	if w.Buffer(tmpl) {
 		return ResolveEvent{Complete: false}, nil
 	}
 

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -137,6 +137,7 @@ func TestResolverRun(t *testing.T) {
 		w := blindWatcher()
 		defer w.Stop()
 		tt := echoTemplate("foo")
+		w.Register(tt)
 		w.SetBufferPeriod(time.Millisecond, time.Second, tt.ID())
 
 		r, err := rv.Run(tt, w)

--- a/template.go
+++ b/template.go
@@ -21,6 +21,9 @@ var ErrNoNewValues = errors.New("no new values for template")
 // The template retains the relationship between it's contents and is
 // responsible for it's own execution.
 type Template struct {
+	// template name, appened to ID (random if not specified)
+	name string
+
 	// contents is the string contents for the template. It is either given
 	// during template creation or read from disk when initialized.
 	contents string
@@ -79,6 +82,11 @@ type Recaller func(dep.Dependency) (value interface{}, found bool)
 
 // TemplateInput is used as input when creating the template.
 type TemplateInput struct {
+
+	// Optional name for the template. Appended to the ID. Required if you want
+	// to use the same content in more than one template with the same Watcher.
+	Name string
+
 	// Contents are the raw template contents.
 	Contents string
 
@@ -114,6 +122,7 @@ type TemplateInput struct {
 func NewTemplate(i TemplateInput) *Template {
 
 	var t Template
+	t.name = i.Name
 	t.contents = i.Contents
 	t.leftDelim = i.LeftDelim
 	t.rightDelim = i.RightDelim
@@ -132,7 +141,11 @@ func NewTemplate(i TemplateInput) *Template {
 }
 
 // ID returns the identifier for this template.
+// Used to uniquely identify this template object for dependency management.
 func (t *Template) ID() string {
+	if t.name != "" {
+		return t.hexMD5 + "_" + t.name
+	}
 	return t.hexMD5
 }
 

--- a/template_test.go
+++ b/template_test.go
@@ -24,15 +24,17 @@ func TestNewTemplate(t *testing.T) {
 	}{
 		{
 			"nil",
-			TemplateInput{},
-			NewTemplate(TemplateInput{}),
+			TemplateInput{Name: "nil"},
+			NewTemplate(TemplateInput{Name: "nil"}),
 		},
 		{
 			"contents",
 			TemplateInput{
+				Name:     "test",
 				Contents: "test",
 			},
 			&Template{
+				name:     "test",
 				contents: "test",
 				hexMD5:   "098f6bcd4621d373cade4e832627b4f6",
 			},
@@ -40,11 +42,13 @@ func TestNewTemplate(t *testing.T) {
 		{
 			"custom_delims",
 			TemplateInput{
+				Name:       "test",
 				Contents:   "test",
 				LeftDelim:  "<<",
 				RightDelim: ">>",
 			},
 			&Template{
+				name:       "test",
 				contents:   "test",
 				hexMD5:     "098f6bcd4621d373cade4e832627b4f6",
 				leftDelim:  "<<",
@@ -54,10 +58,12 @@ func TestNewTemplate(t *testing.T) {
 		{
 			"err_missing_key",
 			TemplateInput{
+				Name:          "test",
 				Contents:      "test",
 				ErrMissingKey: true,
 			},
 			&Template{
+				name:          "test",
 				contents:      "test",
 				hexMD5:        "098f6bcd4621d373cade4e832627b4f6",
 				errMissingKey: true,
@@ -74,6 +80,29 @@ func TestNewTemplate(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("explicit_name_checks", func(t *testing.T) {
+		contentsMD5 := "098f6bcd4621d373cade4e832627b4f6"
+
+		tmpl := NewTemplate(
+			TemplateInput{
+				Name:     "foo",
+				Contents: "test",
+			})
+		if tmpl.ID() != (contentsMD5 + "_foo") {
+			t.Fatalf("ID is wrong, got '%s', want '%s'\n", tmpl.ID(),
+				contentsMD5+"_foo")
+		}
+
+		tmpl = NewTemplate(
+			TemplateInput{
+				Contents: "test",
+			})
+		if tmpl.ID() != contentsMD5 {
+			t.Fatalf("ID is wrong, got '%s', want '%s'\n", tmpl.ID(), contentsMD5)
+		}
+
+	})
 }
 
 func TestTemplate_Execute(t *testing.T) {

--- a/tfunc/consul_test.go
+++ b/tfunc/consul_test.go
@@ -200,7 +200,7 @@ type fakeWatcher struct {
 	*hcat.Store
 }
 
-func (fakeWatcher) Buffer(string) bool            { return false }
+func (fakeWatcher) Buffer(hcat.Notifier) bool     { return false }
 func (f fakeWatcher) Complete(hcat.Notifier) bool { return true }
 func (f fakeWatcher) Recaller(hcat.Notifier) hcat.Recaller {
 	return func(d dep.Dependency) (value interface{}, found bool) {

--- a/watcher.go
+++ b/watcher.go
@@ -2,6 +2,7 @@ package hcat
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -12,6 +13,9 @@ import (
 
 // dataBufferSize is the default number of views to process in a batch.
 const dataBufferSize = 2048
+
+// standard error returned when you try to register the same notifier twice
+var RegistryErr = fmt.Errorf("duplicate watcher registry entry")
 
 // RetryFunc defines the function type used to determine how many and how often
 // to retry calls to the external services.
@@ -147,7 +151,11 @@ func (w *Watcher) WatchVaultToken(token string) error {
 			return errors.Wrap(err, "watcher")
 		}
 		// fakeNotifier is defined near end of file
-		w.Register(fakeNotifier(vaultTokenDummyTemplateID), vt)
+		n := fakeNotifier(vaultTokenDummyTemplateID)
+		if err := w.Register(n); err != nil {
+			return err
+		}
+		w.Track(n, vt)
 		w.Poll(vt)
 	}
 	return nil
@@ -249,18 +257,29 @@ func (w *Watcher) Buffer(tmplID string) bool {
 	return w.bufferTemplates.Buffer(tmplID)
 }
 
-// Register is used to add dependencies to be monitored by the watcher. It sets
-// everything up but stops short of running the polling, waiting for an
-// explicit start.
-// If the dependency is already registered, no action is taken.
-func (w *Watcher) Register(n Notifier, d dep.Dependency) {
-	w.register(n, d)
+// Register's one or more Notifiers with the Watcher for future use.
+// Trying to register the same Notifier twice will result in an error and none
+// of the Notifiers will be registered (all or nothing).
+// Trying to use a Notifier without Registering it will result in a *panic*.
+func (w *Watcher) Register(ns ...Notifier) error {
+	return w.tracker.registerNotifiers(ns...)
 }
 
-// register is private form of Register that returns the new view.
+// Track is used to add dependencies to be monitored by the watcher. It sets
+// everything up but stops short of running the polling, waiting for an
+// explicit start (see Poll below).
+// It calls Register as a convenience, but ignores the returned error so it can
+// be used with already Registered Notifiers.
+// If the dependency is already registered, no action is taken.
+func (w *Watcher) Track(n Notifier, d dep.Dependency) {
+	w.Register(n)
+	w.track(n, d)
+}
+
+// track is the private form of Track that returns the new view.
 // Returned view is useful internally and for testing.
 // Private as we don't want `view` public at this point.
-func (w *Watcher) register(n Notifier, d dep.Dependency) *view {
+func (w *Watcher) track(n Notifier, d dep.Dependency) *view {
 	w.tracker.inUse(n, d)
 	if v, ok := w.tracker.lookup(n, d); ok {
 		return v
@@ -308,7 +327,7 @@ func (w *Watcher) Poll(deps ...dep.Dependency) {
 // to enable tracking dependencies on the Watcher.
 func (w *Watcher) Recaller(n Notifier) Recaller {
 	return func(dep dep.Dependency) (interface{}, bool) {
-		w.register(n, dep)
+		w.track(n, dep)
 		data, ok := w.cache.Recall(dep.String())
 		switch {
 		case ok:
@@ -326,7 +345,7 @@ func (w *Watcher) Complete(n Notifier) bool {
 }
 
 // Mark-n-Sweep garbage-collector-like cleaning of views that are no in use.
-// Stops the views and removes all references.
+// Stops the (garbage) views and removes all references.
 // Should be used before/after the code that uses the dependencies (eg. template).
 //
 // Mark's all tracked dependencies as being *not* in use.
@@ -470,6 +489,23 @@ func (t *tracker) viewCount() int {
 	return len(t.views)
 }
 
+// registerNotifiers adds the notifiers to those tracked, it returns an error
+// if a notifier (indexed by n.ID()) has already been registered. If an error
+// occurs none of the notifiers will be added (all or nothing).
+func (t *tracker) registerNotifiers(ns ...Notifier) error {
+	t.Lock()
+	defer t.Unlock()
+	for _, n := range ns {
+		if _, ok := t.notifiers[n.ID()]; ok {
+			return RegistryErr
+		}
+	}
+	for _, n := range ns {
+		t.notifiers[n.ID()] = n
+	}
+	return nil
+}
+
 // lookup returns the view and true, or nil and false
 // true is returned if the notifier and depencency match a tracked pair
 // returns the view as it is the 1 thing that you don't have yet
@@ -502,7 +538,7 @@ func (t *tracker) add(v *view, n Notifier) {
 		t.views[v.ID()] = v
 	}
 	if _, ok := t.notifiers[n.ID()]; !ok {
-		t.notifiers[n.ID()] = n
+		panic("attempt to use an unregistered notifier")
 	}
 	t.tracked = append(t.tracked,
 		trackedPair{view: v.ID(), notify: n.ID(), inUse: true})


### PR DESCRIPTION
- adds a 'name' field to templates that gets appended to the ID to ensure
  they are unique and can be added the the watche
- 'name' field is optional, ID defaults to just the md5hex if not set
- explicit Register call to the watcher with checks to ensure each Notifier
  is unique and returns an error if registering a duplicate
- attempting to use unregistered Notifier results in a panic
- changes the old Register/register methods to Track/track which more
  closely aligns with their use (and freed up Register)

These semantics should allow multiple parallel uses of the same template
content, with different instances to work while letting the developer
structure the code to ensure everything lines up.

It eliminates the "auto-registering on first use" that was used before
as there was no way for it to properly check (and provide an error) that
the Notifier was a duplicate.