### PR TITLE
Add v1 keys template function for KV API

### DIFF
--- a/consul_v1.go
+++ b/consul_v1.go
@@ -18,6 +18,7 @@ func FuncMapConsulV1() template.FuncMap {
 		"service":  v1ServiceFunc,
 		"connect":  v1ConnectFunc,
 		"services": v1ServicesFunc,
+		"keys":     v1KVListFunc,
 
 		// Set of Consul functions that are not yet implemented for v1. These
 		// intentionally error instead of defaulting to the v0 implementations
@@ -102,6 +103,31 @@ func v1ConnectFunc(recall Recaller) interface{} {
 
 		if value, ok := recall(d); ok {
 			return value.([]*dep.HealthService), nil
+		}
+
+		return result, nil
+	}
+}
+
+// v1KVListFunc returns list of key value pairs
+//
+// Endpoint: /v1/kv/:prefix?recurse
+// Template: {{ keys "prefix" <filter options> ... }}
+func v1KVListFunc(recall Recaller) interface{} {
+	return func(prefix string, opts ...string) ([]*dep.KeyPair, error) {
+		result := []*dep.KeyPair{}
+
+		if prefix == "" {
+			return result, nil
+		}
+
+		d, err := idep.NewKVListQueryV1(prefix, opts)
+		if err != nil {
+			return nil, err
+		}
+
+		if value, ok := recall(d); ok {
+			return value.([]*dep.KeyPair), nil
 		}
 
 		return result, nil

--- a/consul_v1_test.go
+++ b/consul_v1_test.go
@@ -130,6 +130,32 @@ func TestTemplateExecute_consul_v1(t *testing.T) {
 			"[dc1 dc2]",
 			false,
 		},
+		{
+			"func_keys",
+			TemplateInput{
+				Contents: `{{ range keys "key" }}{{ .Key }}:{{ .Value }};{{ end }}`,
+			},
+			func() *Store {
+				st := NewStore()
+				d, err := idep.NewKVListQueryV1("key", []string{})
+				if err != nil {
+					t.Fatal(err)
+				}
+				st.Save(d.String(), []*dep.KeyPair{
+					{
+						Key:   "key",
+						Value: "value-1",
+					},
+					{
+						Key:   "key/test",
+						Value: "value-2",
+					},
+				})
+				return st
+			}(),
+			"key:value-1;key/test:value-2;",
+			false,
+		},
 	}
 
 	for _, tc := range cases {

--- a/internal/dependency/kv_list.go
+++ b/internal/dependency/kv_list.go
@@ -82,6 +82,7 @@ func NewKVListQuery(s string) (*KVListQuery, error) {
 		stopCh: make(chan struct{}, 1),
 		dc:     m["dc"],
 		prefix: m["prefix"],
+		ns:     "",
 	}, nil
 }
 

--- a/internal/dependency/kv_list_test.go
+++ b/internal/dependency/kv_list_test.go
@@ -145,6 +145,183 @@ func TestNewKVListQuery(t *testing.T) {
 	}
 }
 
+func TestNewKVListQueryV1(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		prefix string
+		opts   []string
+		exp    *KVListQuery
+		err    bool
+	}{
+		{
+			"empty",
+			"",
+			[]string{},
+			nil,
+			true,
+		},
+		{
+			"prefix",
+			"prefix",
+			[]string{},
+			&KVListQuery{
+				prefix: "prefix",
+			},
+			false,
+		},
+		{
+			"query_parameters_without_prefix",
+			"",
+			[]string{"dc=dc1"},
+			nil,
+			true,
+		},
+		{
+			"dc",
+			"prefix",
+			[]string{"dc=dc1"},
+			&KVListQuery{
+				prefix: "prefix",
+				dc:     "dc1",
+			},
+			false,
+		},
+		{
+			"namespace",
+			"prefix",
+			[]string{"ns=test"},
+			&KVListQuery{
+				prefix: "prefix",
+				ns:     "test",
+			},
+			false,
+		},
+		{
+			"all_parameters",
+			"prefix",
+			[]string{"dc=dc1", "ns=test"},
+			&KVListQuery{
+				prefix: "prefix",
+				dc:     "dc1",
+				ns:     "test",
+			},
+			false,
+		},
+		{
+			"invalid_parameter",
+			"",
+			[]string{"invalid=param"},
+			nil,
+			true,
+		},
+		{
+			"dots",
+			"prefix.with.dots",
+			[]string{},
+			&KVListQuery{
+				prefix: "prefix.with.dots",
+			},
+			false,
+		},
+		{
+			"slashes",
+			"prefix/with/slashes",
+			[]string{},
+			&KVListQuery{
+				prefix: "prefix/with/slashes",
+			},
+			false,
+		},
+		{
+			"dashes",
+			"prefix-with-dashes",
+			[]string{},
+			&KVListQuery{
+				prefix: "prefix-with-dashes",
+			},
+			false,
+		},
+		{
+			"leading_slash",
+			"/leading/slash",
+			[]string{},
+			&KVListQuery{
+				prefix: "leading/slash",
+			},
+			false,
+		},
+		{
+			"trailing_slash",
+			"trailing/slash/",
+			[]string{},
+			&KVListQuery{
+				prefix: "trailing/slash/",
+			},
+			false,
+		},
+		{
+			"underscores",
+			"prefix_with_underscores",
+			[]string{},
+			&KVListQuery{
+				prefix: "prefix_with_underscores",
+			},
+			false,
+		},
+		{
+			"special_characters",
+			"config/facet:größe-lf-si",
+			[]string{},
+			&KVListQuery{
+				prefix: "config/facet:größe-lf-si",
+			},
+			false,
+		},
+		{
+			"splat",
+			"config/*/timeouts/",
+			[]string{},
+			&KVListQuery{
+				prefix: "config/*/timeouts/",
+			},
+			false,
+		},
+		{
+			"slash",
+			"/",
+			[]string{},
+			nil,
+			true,
+		},
+		{
+			"slash-slash",
+			"//",
+			[]string{},
+			&KVListQuery{
+				prefix: "/",
+			},
+			false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			act, err := NewKVListQueryV1(tc.prefix, tc.opts)
+			if act != nil {
+				act.stopCh = nil
+			}
+
+			if tc.err {
+				assert.Error(t, err)
+			} else {
+				assert.Equal(t, tc.exp, act)
+			}
+		})
+	}
+}
+
 func TestKVListQuery_Fetch(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Adds support for specifying query paramters in the V1 format of key-pair
for the getting a list of key value pairs based on the given prefix.