### PR TITLE
Add v1 key and keyExists template functions for KV API

### DIFF
--- a/consul_v1.go
+++ b/consul_v1.go
@@ -19,6 +19,7 @@ func FuncMapConsulV1() template.FuncMap {
 		"connect":  v1ConnectFunc,
 		"services": v1ServicesFunc,
 		"keys":     v1KVListFunc,
+		"key":      v1KVGetFunc,
 
 		// Set of Consul functions that are not yet implemented for v1. These
 		// intentionally error instead of defaulting to the v0 implementations
@@ -128,6 +129,31 @@ func v1KVListFunc(recall Recaller) interface{} {
 
 		if value, ok := recall(d); ok {
 			return value.([]*dep.KeyPair), nil
+		}
+
+		return result, nil
+	}
+}
+
+// v1KVGetKeyFunc returns a single key value if it exists
+//
+// Endpoint: /v1/kv/:key
+// Template: {{ key "key" <filter options> ... }}
+func v1KVGetFunc(recall Recaller) interface{} {
+	return func(key string, opts ...string) (dep.KvValue, error) {
+		var result dep.KvValue
+
+		if key == "" {
+			return result, nil
+		}
+
+		d, err := idep.NewKVGetQueryV1(key, opts)
+		if err != nil {
+			return "", err
+		}
+
+		if value, ok := recall(d); ok {
+			return value.(dep.KvValue), nil
 		}
 
 		return result, nil

--- a/consul_v1.go
+++ b/consul_v1.go
@@ -15,11 +15,12 @@ var errFuncNotImplemented = fmt.Errorf("function is not implemented")
 // namespaces.
 func FuncMapConsulV1() template.FuncMap {
 	return template.FuncMap{
-		"service":  v1ServiceFunc,
-		"connect":  v1ConnectFunc,
-		"services": v1ServicesFunc,
-		"keys":     v1KVListFunc,
-		"key":      v1KVGetFunc,
+		"service":   v1ServiceFunc,
+		"connect":   v1ConnectFunc,
+		"services":  v1ServicesFunc,
+		"keys":      v1KVListFunc,
+		"key":       v1KVGetFunc,
+		"keyExists": v1KVExistsFunc,
 
 		// Set of Consul functions that are not yet implemented for v1. These
 		// intentionally error instead of defaulting to the v0 implementations
@@ -154,6 +155,31 @@ func v1KVGetFunc(recall Recaller) interface{} {
 
 		if value, ok := recall(d); ok {
 			return value.(dep.KvValue), nil
+		}
+
+		return result, nil
+	}
+}
+
+// v1KVGetKeyFunc returns if a  key value exists
+//
+// Endpoint: /v1/kv/:key
+// Template: {{ key "key" <filter options> ... }}
+func v1KVExistsFunc(recall Recaller) interface{} {
+	return func(key string, opts ...string) (dep.KVExists, error) {
+		var result dep.KVExists
+
+		if key == "" {
+			return result, nil
+		}
+
+		d, err := idep.NewKVExistsQueryV1(key, opts)
+		if err != nil {
+			return dep.KVExists(false), err
+		}
+
+		if value, ok := recall(d); ok {
+			return value.(dep.KVExists), nil
 		}
 
 		return result, nil

--- a/consul_v1.go
+++ b/consul_v1.go
@@ -136,7 +136,7 @@ func v1KVListFunc(recall Recaller) interface{} {
 	}
 }
 
-// v1KVGetKeyFunc returns a single key value if it exists
+// v1KVGetFunc returns a single key value if it exists
 //
 // Endpoint: /v1/kv/:key
 // Template: {{ key "key" <filter options> ... }}
@@ -161,10 +161,10 @@ func v1KVGetFunc(recall Recaller) interface{} {
 	}
 }
 
-// v1KVGetKeyFunc returns if a  key value exists
+// v1KVExistsFunc returns if a  key value exists
 //
 // Endpoint: /v1/kv/:key
-// Template: {{ key "key" <filter options> ... }}
+// Template: {{ keyExists "key" <filter options> ... }}
 func v1KVExistsFunc(recall Recaller) interface{} {
 	return func(key string, opts ...string) (dep.KVExists, error) {
 		var result dep.KVExists

--- a/consul_v1_test.go
+++ b/consul_v1_test.go
@@ -156,6 +156,23 @@ func TestTemplateExecute_consul_v1(t *testing.T) {
 			"key:value-1;key/test:value-2;",
 			false,
 		},
+		{
+			"func_key",
+			TemplateInput{
+				Contents: `{{ key "key" }}`,
+			},
+			func() *Store {
+				st := NewStore()
+				d, err := idep.NewKVGetQueryV1("key", []string{})
+				if err != nil {
+					t.Fatal(err)
+				}
+				st.Save(d.String(), dep.KvValue("test"))
+				return st
+			}(),
+			"test",
+			false,
+		},
 	}
 
 	for _, tc := range cases {

--- a/consul_v1_test.go
+++ b/consul_v1_test.go
@@ -173,6 +173,23 @@ func TestTemplateExecute_consul_v1(t *testing.T) {
 			"test",
 			false,
 		},
+		{
+			"func_key_exists",
+			TemplateInput{
+				Contents: `{{ keyExists "key" }}`,
+			},
+			func() *Store {
+				st := NewStore()
+				d, err := idep.NewKVExistsQueryV1("key", []string{})
+				if err != nil {
+					t.Fatal(err)
+				}
+				st.Save(d.String(), dep.KVExists(true))
+				return st
+			}(),
+			"true",
+			false,
+		},
 	}
 
 	for _, tc := range cases {

--- a/dep/template_function_types.go
+++ b/dep/template_function_types.go
@@ -66,6 +66,8 @@ type HealthService struct {
 // KvValue is here to type the KV return string
 type KvValue string
 
+type KVExists bool
+
 // KeyPair is a simple Key-Value pair
 type KeyPair struct {
 	Path  string

--- a/internal/dependency/kv_exists.go
+++ b/internal/dependency/kv_exists.go
@@ -80,7 +80,7 @@ func NewKVExistsQueryV1(key string, opts []string) (*KVExistsQuery, error) {
 
 // NewKVExistsQuery parses a string into a KV lookup.
 func NewKVExistsQuery(s string) (*KVExistsQuery, error) {
-	if s != "" && !KVExistsQueryRe.MatchString(s) {
+	if !KVExistsQueryRe.MatchString(s) {
 		return nil, fmt.Errorf("kv.exists: invalid format: %q", s)
 	}
 

--- a/internal/dependency/kv_exists.go
+++ b/internal/dependency/kv_exists.go
@@ -2,6 +2,7 @@ package dependency
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/hashicorp/hcat/dep"
@@ -11,6 +12,9 @@ import (
 var (
 	// Ensure implements
 	_ isDependency = (*KVExistsQuery)(nil)
+
+	// KVExistsQueryRe is the regular expression to use.
+	KVExistsQueryRe = regexp.MustCompile(`\A` + keyRe + dcRe + `\z`)
 )
 
 // KVExistsQuery uses a non-blocking query with the KV store for key lookup.
@@ -38,7 +42,7 @@ func (d *KVExistsQuery) String() string {
 	return fmt.Sprintf("kv.exists(%s)", key)
 }
 
-// NewKVGetQueryV1 processes options in the format of "key key=value"
+// NewKVExistsQueryV1 processes options in the format of "key key=value"
 // e.g. "my/key dc=dc1"
 func NewKVExistsQueryV1(key string, opts []string) (*KVExistsQuery, error) {
 	if key == "" || key == "/" {
@@ -74,17 +78,18 @@ func NewKVExistsQueryV1(key string, opts []string) (*KVExistsQuery, error) {
 	return &q, nil
 }
 
-// NewKVGetQuery parses a string into a KV lookup.
+// NewKVExistsQuery parses a string into a KV lookup.
 func NewKVExistsQuery(s string) (*KVExistsQuery, error) {
-	if s != "" && !KVGetQueryRe.MatchString(s) {
+	if s != "" && !KVExistsQueryRe.MatchString(s) {
 		return nil, fmt.Errorf("kv.exists: invalid format: %q", s)
 	}
 
-	m := regexpMatch(KVGetQueryRe, s)
+	m := regexpMatch(KVExistsQueryRe, s)
 	return &KVExistsQuery{
 		stopCh: make(chan struct{}, 1),
 		dc:     m["dc"],
 		key:    m["key"],
+		ns:     "",
 	}, nil
 }
 

--- a/internal/dependency/kv_exists.go
+++ b/internal/dependency/kv_exists.go
@@ -1,0 +1,129 @@
+package dependency
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/hcat/dep"
+	"github.com/pkg/errors"
+)
+
+var (
+	// Ensure implements
+	_ isDependency = (*KVExistsQuery)(nil)
+)
+
+// KVExistsQuery uses a non-blocking query with the KV store for key lookup.
+type KVExistsQuery struct {
+	isConsul
+	stopCh chan struct{}
+
+	dc   string
+	key  string
+	ns   string
+	opts QueryOptions
+}
+
+func (d *KVExistsQuery) SetOptions(opts QueryOptions) {
+	opts.WaitIndex = 0
+	opts.WaitTime = 0
+	d.opts = opts
+}
+
+func (d *KVExistsQuery) String() string {
+	key := d.key
+	if d.dc != "" {
+		key = key + "@" + d.dc
+	}
+	return fmt.Sprintf("kv.exists(%s)", key)
+}
+
+// NewKVGetQueryV1 processes options in the format of "key key=value"
+// e.g. "my/key dc=dc1"
+func NewKVExistsQueryV1(key string, opts []string) (*KVExistsQuery, error) {
+	if key == "" || key == "/" {
+		return nil, fmt.Errorf("kv.exists: key required")
+	}
+
+	q := KVExistsQuery{
+		stopCh: make(chan struct{}, 1),
+		key:    strings.TrimPrefix(key, "/"),
+	}
+	for _, opt := range opts {
+		if strings.TrimSpace(opt) == "" {
+			continue
+		}
+		queryParam := strings.Split(opt, "=")
+		if len(queryParam) != 2 {
+			return nil, fmt.Errorf(
+				"kv.exists: invalid query parameter format: %q", opt)
+		}
+		query := strings.TrimSpace(queryParam[0])
+		value := strings.TrimSpace(queryParam[1])
+		switch query {
+		case "dc", "datacenter":
+			q.dc = value
+		case "ns", "namespace":
+			q.ns = value
+		default:
+			return nil, fmt.Errorf(
+				"kv.exists: invalid query parameter: %q", opt)
+		}
+	}
+
+	return &q, nil
+}
+
+// NewKVGetQuery parses a string into a KV lookup.
+func NewKVExistsQuery(s string) (*KVExistsQuery, error) {
+	if s != "" && !KVGetQueryRe.MatchString(s) {
+		return nil, fmt.Errorf("kv.exists: invalid format: %q", s)
+	}
+
+	m := regexpMatch(KVGetQueryRe, s)
+	return &KVExistsQuery{
+		stopCh: make(chan struct{}, 1),
+		dc:     m["dc"],
+		key:    m["key"],
+	}, nil
+}
+
+// Fetch queries the Consul API defined by the given client.
+func (d *KVExistsQuery) Fetch(clients dep.Clients) (interface{}, *dep.ResponseMetadata, error) {
+	select {
+	case <-d.stopCh:
+		return nil, nil, ErrStopped
+	default:
+	}
+
+	opts := d.opts.Merge(&QueryOptions{
+		Datacenter: d.dc,
+		Namespace:  d.ns,
+	})
+
+	pair, qm, err := clients.Consul().KV().Get(d.key, opts.ToConsulOpts())
+	if err != nil {
+		return nil, nil, errors.Wrap(err, d.String())
+	}
+
+	rm := &dep.ResponseMetadata{
+		LastIndex:   qm.LastIndex,
+		LastContact: qm.LastContact,
+	}
+
+	if pair == nil {
+		return dep.KVExists(false), rm, nil
+	}
+
+	return dep.KVExists(true), rm, nil
+}
+
+// Stop halts the dependency's fetch function.
+func (d *KVExistsQuery) Stop() {
+	close(d.stopCh)
+}
+
+// CanShare returns a boolean if this dependency is shareable.
+func (d *KVExistsQuery) CanShare() bool {
+	return true
+}

--- a/internal/dependency/kv_exists.go
+++ b/internal/dependency/kv_exists.go
@@ -57,13 +57,11 @@ func NewKVExistsQueryV1(key string, opts []string) (*KVExistsQuery, error) {
 		if strings.TrimSpace(opt) == "" {
 			continue
 		}
-		queryParam := strings.Split(opt, "=")
-		if len(queryParam) != 2 {
+		query, value, err := stringsSplit2(opt, "=")
+		if err != nil {
 			return nil, fmt.Errorf(
 				"kv.exists: invalid query parameter format: %q", opt)
 		}
-		query := strings.TrimSpace(queryParam[0])
-		value := strings.TrimSpace(queryParam[1])
 		switch query {
 		case "dc", "datacenter":
 			q.dc = value

--- a/internal/dependency/kv_exists_test.go
+++ b/internal/dependency/kv_exists_test.go
@@ -24,11 +24,12 @@ func TestKVExistsQuery_SetOptions(t *testing.T) {
 		t.Fatal(err)
 	}
 	q.SetOptions(QueryOptions{WaitIndex: 100, WaitTime: 100})
+	// WaitIndex and WaitTime should always be 0 regardless of query options
 	if q.opts.WaitIndex != 0 {
-		t.Fatal("WaitIndex should be zero")
+		t.Fatal("WaitIndex should be 0")
 	}
 	if q.opts.WaitTime != 0 {
-		t.Fatal("WaitTime should be zero")
+		t.Fatal("WaitTime should be 0")
 	}
 }
 

--- a/internal/dependency/kv_exists_test.go
+++ b/internal/dependency/kv_exists_test.go
@@ -223,6 +223,12 @@ func TestNewKVExistsQueryV1WithParameters(t *testing.T) {
 			[]string{"invalid=param"},
 			nil,
 		},
+		{
+			"invalid_format",
+			"key",
+			[]string{"invalid-param"},
+			nil,
+		},
 	}
 
 	for _, tc := range cases {

--- a/internal/dependency/kv_get.go
+++ b/internal/dependency/kv_get.go
@@ -39,6 +39,10 @@ func NewKVGetQueryV1(key string, opts []string) (*KVGetQuery, error) {
 
 // NewKVGetQuery parses a string into a (non-blocking) KV lookup.
 func NewKVGetQuery(s string) (*KVGetQuery, error) {
+	if !KVGetQueryRe.MatchString(s) {
+		return nil, fmt.Errorf("kv.get: invalid format: %q", s)
+	}
+
 	q, err := NewKVExistsQuery(s)
 	if err != nil {
 		return nil, err

--- a/internal/dependency/kv_get.go
+++ b/internal/dependency/kv_get.go
@@ -26,7 +26,7 @@ type KVGetQuery struct {
 // NewKVGetQueryV1 processes options in the format of "key key=value"
 // e.g. "my/key dc=dc1"
 func NewKVGetQueryV1(key string, opts []string) (*KVGetQuery, error) {
-	if key == "" {
+	if key == "" || key == "/" {
 		return nil, fmt.Errorf("kv.get: key required")
 	}
 

--- a/internal/dependency/kv_get.go
+++ b/internal/dependency/kv_get.go
@@ -3,7 +3,6 @@ package dependency
 import (
 	"fmt"
 	"regexp"
-	"strings"
 
 	"github.com/hashicorp/hcat/dep"
 	"github.com/pkg/errors"
@@ -18,84 +17,10 @@ var (
 	KVGetQueryRe = regexp.MustCompile(`\A` + keyRe + dcRe + `\z`)
 )
 
-// KVExistsQuery uses a non-blocking query with the KV store for key lookup.
-type KVExistsQuery struct {
-	isConsul
-	stopCh chan struct{}
-
-	dc   string
-	key  string
-	ns   string
-	opts QueryOptions
-}
-
 // KVGetQuery queries the KV store for a single key.
 type KVGetQuery struct {
 	KVExistsQuery
 	isBlocking
-}
-
-func (d *KVExistsQuery) SetOptions(opts QueryOptions) {
-	opts.WaitIndex = 0
-	opts.WaitTime = 0
-	d.opts = opts
-}
-func (d *KVExistsQuery) String() string {
-	key := d.key
-	if d.dc != "" {
-		key = key + "@" + d.dc
-	}
-	return fmt.Sprintf("kv.exists(%s)", key)
-}
-
-// NewKVGetQueryV1 processes options in the format of "key key=value"
-// e.g. "my/key dc=dc1"
-func NewKVExistsQueryV1(key string, opts []string) (*KVExistsQuery, error) {
-	if key == "" || key == "/" {
-		return nil, fmt.Errorf("kv.get: key required")
-	}
-
-	q := KVExistsQuery{
-		stopCh: make(chan struct{}, 1),
-		key:    strings.TrimPrefix(key, "/"),
-	}
-	for _, opt := range opts {
-		if strings.TrimSpace(opt) == "" {
-			continue
-		}
-		queryParam := strings.Split(opt, "=")
-		if len(queryParam) != 2 {
-			return nil, fmt.Errorf(
-				"kv.get: invalid query parameter format: %q", opt)
-		}
-		query := strings.TrimSpace(queryParam[0])
-		value := strings.TrimSpace(queryParam[1])
-		switch query {
-		case "dc", "datacenter":
-			q.dc = value
-		case "ns", "namespace":
-			q.ns = value
-		default:
-			return nil, fmt.Errorf(
-				"kv.get: invalid query parameter: %q", opt)
-		}
-	}
-
-	return &q, nil
-}
-
-// NewKVGetQuery parses a string into a KV lookup.
-func NewKVExistsQuery(s string) (*KVExistsQuery, error) {
-	if s != "" && !KVGetQueryRe.MatchString(s) {
-		return nil, fmt.Errorf("kv.get: invalid format: %q", s)
-	}
-
-	m := regexpMatch(KVGetQueryRe, s)
-	return &KVExistsQuery{
-		stopCh: make(chan struct{}, 1),
-		dc:     m["dc"],
-		key:    m["key"],
-	}, nil
 }
 
 // NewKVGetQueryV1 processes options in the format of "key key=value"

--- a/internal/dependency/kv_get_test.go
+++ b/internal/dependency/kv_get_test.go
@@ -26,10 +26,10 @@ func TestKVGetQuery_SetOptions(t *testing.T) {
 	}
 	q.SetOptions(QueryOptions{WaitIndex: 100, WaitTime: 100})
 	if q.opts.WaitIndex != 100 {
-		t.Fatal("WaitIndex should be zero")
+		t.Fatal("WaitIndex should be 100")
 	}
 	if q.opts.WaitTime != 100 {
-		t.Fatal("WaitTime should be zero")
+		t.Fatal("WaitTime should be 100")
 	}
 }
 

--- a/internal/dependency/kv_get_test.go
+++ b/internal/dependency/kv_get_test.go
@@ -223,6 +223,12 @@ func TestNewKVGetQueryV1WithParameters(t *testing.T) {
 			[]string{"invalid=param"},
 			nil,
 		},
+		{
+			"invalid_format",
+			"key",
+			[]string{"invalid-param"},
+			nil,
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Adds v1 query functions for both key and keyExists. Also splits keyExists into its own file and gives it a dedicated non-blocking Fetch method.

Made the changes off of my `consul-kv-list-v1` branch to avoid merge conflicts on `consul_v1.go`. I'll update to point the PR to master after https://github.com/hashicorp/hcat/pull/63 is reviewed and merged.