### PR TITLE
Add non-blocking key get method

### DIFF
--- a/consul_v1.go
+++ b/consul_v1.go
@@ -15,12 +15,13 @@ var errFuncNotImplemented = fmt.Errorf("function is not implemented")
 // namespaces.
 func FuncMapConsulV1() template.FuncMap {
 	return template.FuncMap{
-		"service":   v1ServiceFunc,
-		"connect":   v1ConnectFunc,
-		"services":  v1ServicesFunc,
-		"keys":      v1KVListFunc,
-		"key":       v1KVGetFunc,
-		"keyExists": v1KVExistsFunc,
+		"service":      v1ServiceFunc,
+		"connect":      v1ConnectFunc,
+		"services":     v1ServicesFunc,
+		"keys":         v1KVListFunc,
+		"key":          v1KVGetFunc,
+		"keyExists":    v1KVExistsFunc,
+		"keyExistsGet": v1KVExistsGetFunc,
 
 		// Set of Consul functions that are not yet implemented for v1. These
 		// intentionally error instead of defaulting to the v0 implementations
@@ -161,7 +162,7 @@ func v1KVGetFunc(recall Recaller) interface{} {
 	}
 }
 
-// v1KVExistsFunc returns if a  key value exists
+// v1KVExistsFunc returns if a key value exists
 //
 // Endpoint: /v1/kv/:key
 // Template: {{ keyExists "key" <filter options> ... }}
@@ -180,6 +181,32 @@ func v1KVExistsFunc(recall Recaller) interface{} {
 
 		if value, ok := recall(d); ok {
 			return value.(dep.KVExists), nil
+		}
+
+		return result, nil
+	}
+}
+
+// v1KVExistsGetFunc checks if a key exists and
+// if the key exists, returns the key-value pair
+//
+// Endpoint: /v1/kv/:key
+// Template: {{ keyExistsGet "key" <filter options> ... }}
+func v1KVExistsGetFunc(recall Recaller) interface{} {
+	return func(key string, opts ...string) (*dep.KeyPair, error) {
+		var result *dep.KeyPair
+
+		if key == "" {
+			return result, nil
+		}
+
+		d, err := idep.NewKVExistsGetQueryV1(key, opts)
+		if err != nil {
+			return result, err
+		}
+
+		if value, ok := recall(d); ok {
+			return value.(*dep.KeyPair), nil
 		}
 
 		return result, nil

--- a/consul_v1_test.go
+++ b/consul_v1_test.go
@@ -190,6 +190,27 @@ func TestTemplateExecute_consul_v1(t *testing.T) {
 			"true",
 			false,
 		},
+		{
+			"func_key_exists_get",
+			TemplateInput{
+				Contents: `{{- with $kv := keyExistsGet "key" }}{{ .Key }}:{{ .Value }}{{- end}}`,
+			},
+			func() *Store {
+				st := NewStore()
+				d, err := idep.NewKVExistsGetQueryV1("key", []string{})
+				if err != nil {
+					t.Fatal(err)
+				}
+				st.Save(d.String(), &dep.KeyPair{
+					Key:    "key",
+					Value:  "value-1",
+					Exists: true,
+				})
+				return st
+			}(),
+			"key:value-1",
+			false,
+		},
 	}
 
 	for _, tc := range cases {

--- a/dep/template_function_types.go
+++ b/dep/template_function_types.go
@@ -70,9 +70,10 @@ type KVExists bool
 
 // KeyPair is a simple Key-Value pair
 type KeyPair struct {
-	Path  string
-	Key   string
-	Value string
+	Path   string
+	Key    string
+	Value  string
+	Exists bool
 
 	// Lesser-used, but still valuable keys from api.KV
 	CreateIndex uint64

--- a/internal/dependency/kv_exists_get.go
+++ b/internal/dependency/kv_exists_get.go
@@ -1,0 +1,105 @@
+package dependency
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/hcat/dep"
+	"github.com/pkg/errors"
+)
+
+var (
+	// Ensure implements
+	_ isDependency = (*KVExistsGetQuery)(nil)
+)
+
+// KVExistsGetQuery uses a non-blocking query to lookup a single key in the KV store.
+// The query returns whether the key exists and the value of the key if it exists.
+type KVExistsGetQuery struct {
+	KVExistsQuery
+}
+
+// NewKVExistsGetQueryV1 processes options in the format of "key key=value"
+// e.g. "my/key dc=dc1"
+func NewKVExistsGetQueryV1(key string, opts []string) (*KVExistsGetQuery, error) {
+	if key == "" || key == "/" {
+		return nil, fmt.Errorf("kv.exists.get: key required")
+	}
+
+	q, err := NewKVExistsQueryV1(key, opts)
+	if err != nil {
+		return nil, err
+	}
+	return &KVExistsGetQuery{KVExistsQuery: *q}, nil
+}
+
+// CanShare returns a boolean if this dependency is shareable.
+func (d *KVExistsGetQuery) CanShare() bool {
+	return true
+}
+
+// String returns the human-friendly version of this dependency.
+func (d *KVExistsGetQuery) String() string {
+	key := d.key
+	if d.dc != "" {
+		key = key + "dc=" + d.dc
+	}
+	if d.ns != "" {
+		key = key + "ns=" + d.ns
+	}
+	return fmt.Sprintf("kv.exists.get(%s)", key)
+}
+
+// Stop halts the dependency's fetch function.
+func (d *KVExistsGetQuery) Stop() {
+	close(d.stopCh)
+}
+
+func (d *KVExistsGetQuery) SetOptions(opts QueryOptions) {
+	opts.WaitIndex = 0
+	opts.WaitTime = 0
+	d.opts = opts
+}
+
+// Fetch queries the Consul API defined by the given client.
+func (d *KVExistsGetQuery) Fetch(clients dep.Clients) (interface{}, *dep.ResponseMetadata, error) {
+	select {
+	case <-d.stopCh:
+		return nil, nil, ErrStopped
+	default:
+	}
+
+	opts := d.opts.Merge(&QueryOptions{
+		Datacenter: d.dc,
+		Namespace:  d.ns,
+	})
+
+	pair, qm, err := clients.Consul().KV().Get(d.key, opts.ToConsulOpts())
+	if err != nil {
+		return nil, nil, errors.Wrap(err, d.String())
+	}
+
+	rm := &dep.ResponseMetadata{
+		LastIndex:   qm.LastIndex,
+		LastContact: qm.LastContact,
+	}
+
+	if pair == nil {
+		return &dep.KeyPair{
+			Path:   d.key,
+			Key:    d.key,
+			Exists: false,
+		}, rm, nil
+	}
+
+	return &dep.KeyPair{
+		Path:        pair.Key,
+		Key:         pair.Key,
+		Value:       string(pair.Value),
+		Exists:      true,
+		CreateIndex: pair.CreateIndex,
+		ModifyIndex: pair.ModifyIndex,
+		LockIndex:   pair.LockIndex,
+		Flags:       pair.Flags,
+		Session:     pair.Session,
+	}, rm, nil
+}

--- a/internal/dependency/kv_exists_get_test.go
+++ b/internal/dependency/kv_exists_get_test.go
@@ -1,0 +1,300 @@
+package dependency
+
+import (
+	"testing"
+
+	"github.com/hashicorp/hcat/dep"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewKVExistsGetQuery_NonBlocking(t *testing.T) {
+	q, err := NewKVExistsGetQueryV1("key", []string{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := interface{}(q).(BlockingQuery); ok {
+		t.Fatal("should NOT be blocking")
+	}
+}
+
+func TestKVExistsGetQuery_SetOptions(t *testing.T) {
+	q, err := NewKVExistsGetQueryV1("key", []string{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	q.SetOptions(QueryOptions{WaitIndex: 100, WaitTime: 100})
+	// WaitIndex and WaitTime should always be 0 regardless of query options
+	if q.opts.WaitIndex != 0 {
+		t.Fatal("WaitIndex should be 0")
+	}
+	if q.opts.WaitTime != 0 {
+		t.Fatal("WaitTime should be 0")
+	}
+}
+
+type newKVExistsGetCase struct {
+	exp *KVExistsQuery
+	act *KVExistsGetQuery
+	err error
+}
+
+func verifyNewKVExistsGetQueryV1(t *testing.T, tc newKVExistsGetCase) {
+	if tc.act != nil {
+		tc.act.stopCh = nil
+	}
+
+	if tc.exp == nil {
+		assert.Error(t, tc.err)
+	} else {
+		exp := &KVExistsGetQuery{KVExistsQuery: *tc.exp}
+		assert.Equal(t, exp, tc.act)
+	}
+}
+
+func TestNewKVExistsGetQueryV1(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		i    string
+		exp  *KVExistsQuery
+	}{
+		{
+			"empty",
+			"",
+			nil,
+		},
+		{
+			"key",
+			"key",
+			&KVExistsQuery{
+				key: "key",
+			},
+		},
+		{
+			"dots",
+			"key.with.dots",
+			&KVExistsQuery{
+				key: "key.with.dots",
+			},
+		},
+		{
+			"slashes",
+			"key/with/slashes",
+			&KVExistsQuery{
+				key: "key/with/slashes",
+			},
+		},
+		{
+			"dashes",
+			"key-with-dashes",
+			&KVExistsQuery{
+				key: "key-with-dashes",
+			},
+		},
+		{
+			"leading_slash",
+			"/leading/slash",
+			&KVExistsQuery{
+				key: "leading/slash",
+			},
+		},
+		{
+			"trailing_slash",
+			"trailing/slash/",
+			&KVExistsQuery{
+				key: "trailing/slash/",
+			},
+		},
+		{
+			"underscores",
+			"key_with_underscores",
+			&KVExistsQuery{
+				key: "key_with_underscores",
+			},
+		},
+		{
+			"special_characters",
+			"config/facet:größe-lf-si",
+			&KVExistsQuery{
+				key: "config/facet:größe-lf-si",
+			},
+		},
+		{
+			"splat",
+			"config/*/timeouts/",
+			&KVExistsQuery{
+				key: "config/*/timeouts/",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			act, err := NewKVExistsGetQueryV1(tc.i, []string{})
+			verifyNewKVExistsGetQueryV1(t, newKVExistsGetCase{tc.exp, act, err})
+		})
+	}
+}
+
+func TestNewKVExistsGetQueryV1WithParameters(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		i    string
+		opts []string
+		exp  *KVExistsQuery
+	}{
+		{
+			"no_key",
+			"",
+			[]string{"dc=dc1"},
+			nil,
+		},
+		{
+			"dc",
+			"key",
+			[]string{"dc=dc1"},
+			&KVExistsQuery{
+				key: "key",
+				dc:  "dc1",
+			},
+		},
+		{
+			"namespace",
+			"key",
+			[]string{"ns=test-namespace"},
+			&KVExistsQuery{
+				key: "key",
+				ns:  "test-namespace",
+			},
+		},
+		{
+			"all_parameters",
+			"key",
+			[]string{"dc=dc1", "ns=test-namespace"},
+			&KVExistsQuery{
+				key: "key",
+				dc:  "dc1",
+				ns:  "test-namespace",
+			},
+		},
+		{
+			"invalid_parameter",
+			"key",
+			[]string{"invalid=param"},
+			nil,
+		},
+		{
+			"invalid_format",
+			"key",
+			[]string{"invalid-param"},
+			nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			act, err := NewKVExistsGetQueryV1(tc.i, tc.opts)
+			verifyNewKVExistsGetQueryV1(t, newKVExistsGetCase{tc.exp, act, err})
+		})
+	}
+}
+
+func TestKVExistsGetQuery_Fetch(t *testing.T) {
+	t.Parallel()
+
+	testConsul.SetKVString(t, "test-kv-get/key", "value")
+	testConsul.SetKVString(t, "test-kv-get/key_empty", "")
+
+	cases := []struct {
+		name string
+		i    string
+		exp  *dep.KeyPair
+	}{
+		{
+			"exists",
+			"test-kv-get/key",
+			&dep.KeyPair{
+				Path:   "test-kv-get/key",
+				Key:    "test-kv-get/key",
+				Exists: true,
+				Value:  "value",
+			},
+		},
+		{
+			"exists_empty_string",
+			"test-kv-get/key_empty",
+			&dep.KeyPair{
+				Path:   "test-kv-get/key_empty",
+				Key:    "test-kv-get/key_empty",
+				Exists: true,
+				Value:  "",
+			},
+		},
+		{
+			"does_not_exist",
+			"test-kv-get/not/a/real/key",
+			&dep.KeyPair{
+				Path:   "test-kv-get/not/a/real/key",
+				Key:    "test-kv-get/not/a/real/key",
+				Exists: false,
+				Value:  "",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d, err := NewKVExistsGetQueryV1(tc.i, []string{})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			kv, _, err := d.Fetch(testClients)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			act, ok := kv.(*dep.KeyPair)
+			assert.True(t, ok, "unexpected dependency type")
+
+			assert.Equal(t, tc.exp.Path, act.Path)
+			assert.Equal(t, tc.exp.Key, act.Key)
+			assert.Equal(t, tc.exp.Exists, act.Exists)
+			assert.Equal(t, tc.exp.Value, act.Value)
+		})
+	}
+}
+
+func TestKVExistsGetQuery_String(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		i    string
+		exp  string
+	}{
+		{
+			"key",
+			"key",
+			"kv.exists.get(key)",
+		},
+		{
+			"opts",
+			"key dc=dc1 ns=ns",
+			"kv.exists.get(key dc=dc1 ns=ns)",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d, err := NewKVExistsGetQueryV1(tc.i, []string{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			assert.Equal(t, tc.exp, d.String())
+		})
+	}
+}

--- a/internal/dependency/kv_list.go
+++ b/internal/dependency/kv_list.go
@@ -120,6 +120,7 @@ func (d *KVListQuery) Fetch(clients dep.Clients) (interface{}, *dep.ResponseMeta
 			Path:        pair.Key,
 			Key:         key,
 			Value:       string(pair.Value),
+			Exists:      true,
 			CreateIndex: pair.CreateIndex,
 			ModifyIndex: pair.ModifyIndex,
 			LockIndex:   pair.LockIndex,

--- a/internal/dependency/kv_list_test.go
+++ b/internal/dependency/kv_list_test.go
@@ -339,19 +339,22 @@ func TestKVListQuery_Fetch(t *testing.T) {
 			"test-kv-list/prefix",
 			[]*dep.KeyPair{
 				{
-					Path:  "test-kv-list/prefix/foo",
-					Key:   "foo",
-					Value: "bar",
+					Path:   "test-kv-list/prefix/foo",
+					Key:    "foo",
+					Value:  "bar",
+					Exists: true,
 				},
 				{
-					Path:  "test-kv-list/prefix/wave/ocean",
-					Key:   "wave/ocean",
-					Value: "sleek",
+					Path:   "test-kv-list/prefix/wave/ocean",
+					Key:    "wave/ocean",
+					Value:  "sleek",
+					Exists: true,
 				},
 				{
-					Path:  "test-kv-list/prefix/zip",
-					Key:   "zip",
-					Value: "zap",
+					Path:   "test-kv-list/prefix/zip",
+					Key:    "zip",
+					Value:  "zap",
+					Exists: true,
 				},
 			},
 		},
@@ -360,19 +363,22 @@ func TestKVListQuery_Fetch(t *testing.T) {
 			"test-kv-list/prefix/",
 			[]*dep.KeyPair{
 				{
-					Path:  "test-kv-list/prefix/foo",
-					Key:   "foo",
-					Value: "bar",
+					Path:   "test-kv-list/prefix/foo",
+					Key:    "foo",
+					Value:  "bar",
+					Exists: true,
 				},
 				{
-					Path:  "test-kv-list/prefix/wave/ocean",
-					Key:   "wave/ocean",
-					Value: "sleek",
+					Path:   "test-kv-list/prefix/wave/ocean",
+					Key:    "wave/ocean",
+					Value:  "sleek",
+					Exists: true,
 				},
 				{
-					Path:  "test-kv-list/prefix/zip",
-					Key:   "zip",
-					Value: "zap",
+					Path:   "test-kv-list/prefix/zip",
+					Key:    "zip",
+					Value:  "zap",
+					Exists: true,
 				},
 			},
 		},
@@ -483,9 +489,10 @@ func TestKVListQuery_Fetch(t *testing.T) {
 			act.ModifyIndex = 0
 
 			exp := &dep.KeyPair{
-				Path:  "test-kv-list/prefix/foo",
-				Key:   "foo",
-				Value: "new-bar",
+				Path:   "test-kv-list/prefix/foo",
+				Key:    "foo",
+				Value:  "new-bar",
+				Exists: true,
 			}
 
 			assert.Equal(t, exp, act)


### PR DESCRIPTION
This method differs from the current key get query because it is non-blocking
and returns a dependency of type KeyPair. It also indicates if it exists or not
through a new attribute on the KeyPair dependency.