### PR TITLE
Revert "Update HealthServiceQueryV1 to default filter for passing services" for CTS dep branch

### DIFF
--- a/internal/dependency/catalog_node_test.go
+++ b/internal/dependency/catalog_node_test.go
@@ -104,27 +104,21 @@ func TestCatalogNodeQuery_Fetch(t *testing.T) {
 					},
 				},
 				Services: []*dep.CatalogNodeService{
-					{
+					&dep.CatalogNodeService{
 						ID:      "consul",
 						Service: "consul",
 						Port:    testConsul.Config.Ports.Server,
 						Tags:    dep.ServiceTags([]string{}),
 						Meta:    map[string]string{},
 					},
-					{
-						ID:      "critical-service",
-						Service: "critical-service",
-						Tags:    dep.ServiceTags([]string{}),
-						Meta:    map[string]string{},
-					},
-					{
+					&dep.CatalogNodeService{
 						ID:      "foo",
 						Service: "foo-sidecar-proxy",
 						Tags:    dep.ServiceTags([]string{}),
 						Meta:    map[string]string{},
 						Port:    21999,
 					},
-					{
+					&dep.CatalogNodeService{
 						ID:      "service-meta",
 						Service: "service-meta",
 						Tags:    dep.ServiceTags([]string{"tag1"}),

--- a/internal/dependency/catalog_services_test.go
+++ b/internal/dependency/catalog_services_test.go
@@ -148,19 +148,15 @@ func TestCatalogServicesQuery_Fetch(t *testing.T) {
 			"all",
 			"",
 			[]*dep.CatalogSnippet{
-				{
+				&dep.CatalogSnippet{
 					Name: "consul",
 					Tags: dep.ServiceTags([]string{}),
 				},
-				{
-					Name: "critical-service",
-					Tags: dep.ServiceTags([]string{}),
-				},
-				{
+				&dep.CatalogSnippet{
 					Name: "foo-sidecar-proxy",
 					Tags: dep.ServiceTags([]string{}),
 				},
-				{
+				&dep.CatalogSnippet{
 					Name: "service-meta",
 					Tags: dep.ServiceTags([]string{"tag1"}),
 				},

--- a/internal/dependency/dependency_test.go
+++ b/internal/dependency/dependency_test.go
@@ -81,20 +81,6 @@ func TestMain(m *testing.M) {
 		Fatalf("%v", err)
 	}
 
-	// service with a critical check
-	criticalService := &api.AgentServiceRegistration{
-		ID:   "critical-service",
-		Name: "critical-service",
-		Check: &api.AgentServiceCheck{
-			HTTP:     "non-existent-url",
-			Status:   HealthCritical,
-			Interval: "10000m", // large interval to unnecessary recheck
-		},
-	}
-	if err := consul_agent.ServiceRegister(criticalService); err != nil {
-		Fatalf("%v", err)
-	}
-
 	exitCh := make(chan int, 1)
 	func() {
 		defer func() {

--- a/internal/dependency/health_service.go
+++ b/internal/dependency/health_service.go
@@ -61,10 +61,6 @@ type HealthServiceQuery struct {
 	// {{ service "tag.service" }} used for the deprecated tag query parameter.
 	// Use the filter parameter with the "Service.Tags" selector instead.
 	deprecatedTag string
-
-	// passingOnly filters for services that have an overall aggregated status
-	// of passing. When true, sdk adds ?passing=1 to api request
-	passingOnly bool
 }
 
 // NewHealthServiceQueryV1 processes the strings to build a service dependency.
@@ -94,11 +90,12 @@ func healthServiceQueryV1(service string, connect bool, opts []string) (*HealthS
 	}
 
 	healthServiceQuery := HealthServiceQuery{
-		stopCh:      make(chan struct{}, 1),
-		connect:     connect,
-		name:        service,
-		passingOnly: true,
+		stopCh:  make(chan struct{}, 1),
+		connect: connect,
+		name:    service,
 	}
+
+	passingOnly := true
 
 	// Split query parameters and filters
 	var filters []string
@@ -126,7 +123,7 @@ func healthServiceQueryV1(service string, connect bool, opts []string) (*HealthS
 
 		if strings.Contains(opt, "Checks.Status") {
 			// Disable if any filter option includes "Checks.Status"
-			healthServiceQuery.passingOnly = false
+			passingOnly = false
 		}
 
 		// Evaluate the grammer of the filter before attempting to query Consul.
@@ -137,6 +134,11 @@ func healthServiceQueryV1(service string, connect bool, opts []string) (*HealthS
 				"health.service: invalid filter: %q for %q: %s", opt, service, err)
 		}
 		filters = append(filters, opt)
+	}
+
+	if passingOnly {
+		// Default to return passing only
+		filters = append(filters, `Checks.Status == "passing"`)
 	}
 
 	if len(filters) > 0 {
@@ -184,7 +186,6 @@ func healthServiceQuery(s string, connect bool) (*HealthServiceQuery, error) {
 		connect:                 connect,
 		deprecatedStatusFilters: filters,
 		deprecatedTag:           m["tag"],
-		passingOnly:             len(filters) == 1 && filters[0] == HealthPassing,
 	}, nil
 }
 
@@ -209,11 +210,16 @@ func (d *HealthServiceQuery) Fetch(clients dep.Clients) (interface{}, *dep.Respo
 	//	RawQuery: opts.String(),
 	//})
 
+	// Check if a user-supplied filter was given. If so, we may be querying for
+	// more than healthy services, so we need to implement client-side
+	// filtering.
+	passingOnly := len(d.deprecatedStatusFilters) == 1 && d.deprecatedStatusFilters[0] == HealthPassing
+
 	nodes := clients.Consul().Health().Service
 	if d.connect {
 		nodes = clients.Consul().Health().Connect
 	}
-	entries, qm, err := nodes(d.name, d.deprecatedTag, d.passingOnly, opts.ToConsulOpts())
+	entries, qm, err := nodes(d.name, d.deprecatedTag, passingOnly, opts.ToConsulOpts())
 	if err != nil {
 		return nil, nil, errors.Wrap(err, d.String())
 	}
@@ -222,11 +228,12 @@ func (d *HealthServiceQuery) Fetch(clients dep.Clients) (interface{}, *dep.Respo
 
 	list := make([]*dep.HealthService, 0, len(entries))
 	for _, entry := range entries {
-		// Determine the overall status of this service from its checks.
+		// Get the status of this service from its checks.
 		status := entry.Checks.AggregatedStatus()
 
-		// Do status filtering on client-side if there are non-passing status filters.
-		if !acceptStatus(d.deprecatedStatusFilters, status) {
+		// If we are not checking only healthy services, client-side filter out
+		// services that do not match the given filter.
+		if len(d.deprecatedStatusFilters) > 0 && !acceptStatus(d.deprecatedStatusFilters, status) {
 			continue
 		}
 
@@ -317,14 +324,10 @@ func (d *HealthServiceQuery) SetOptions(opts QueryOptions) {
 	d.opts = opts
 }
 
-// acceptStatus returns if a check status matches the list of statuses to filter on
-func acceptStatus(filters []string, status string) bool {
-	if len(filters) == 0 {
-		// nothing to filter on, status is acceptable
-		return true
-	}
-	for _, filter := range filters {
-		if filter == status || filter == HealthAny {
+// acceptStatus allows us to check if a slice of health checks pass this filter.
+func acceptStatus(list []string, s string) bool {
+	for _, status := range list {
+		if status == s || status == HealthAny {
 			return true
 		}
 	}

--- a/internal/dependency/health_service_test.go
+++ b/internal/dependency/health_service_test.go
@@ -48,7 +48,6 @@ func TestNewHealthServiceQuery(t *testing.T) {
 			&HealthServiceQuery{
 				deprecatedStatusFilters: []string{"passing"},
 				name:                    "name",
-				passingOnly:             true,
 			},
 			false,
 		},
@@ -59,7 +58,6 @@ func TestNewHealthServiceQuery(t *testing.T) {
 				dc:                      "dc1",
 				deprecatedStatusFilters: []string{"passing"},
 				name:                    "name",
-				passingOnly:             true,
 			},
 			false,
 		},
@@ -71,7 +69,6 @@ func TestNewHealthServiceQuery(t *testing.T) {
 				deprecatedStatusFilters: []string{"passing"},
 				name:                    "name",
 				near:                    "near",
-				passingOnly:             true,
 			},
 			false,
 		},
@@ -82,7 +79,6 @@ func TestNewHealthServiceQuery(t *testing.T) {
 				deprecatedStatusFilters: []string{"passing"},
 				name:                    "name",
 				near:                    "near",
-				passingOnly:             true,
 			},
 			false,
 		},
@@ -93,7 +89,6 @@ func TestNewHealthServiceQuery(t *testing.T) {
 				deprecatedStatusFilters: []string{"passing"},
 				name:                    "name",
 				deprecatedTag:           "tag",
-				passingOnly:             true,
 			},
 			false,
 		},
@@ -105,7 +100,6 @@ func TestNewHealthServiceQuery(t *testing.T) {
 				deprecatedStatusFilters: []string{"passing"},
 				name:                    "name",
 				deprecatedTag:           "tag",
-				passingOnly:             true,
 			},
 			false,
 		},
@@ -117,7 +111,6 @@ func TestNewHealthServiceQuery(t *testing.T) {
 				name:                    "name",
 				near:                    "near",
 				deprecatedTag:           "tag",
-				passingOnly:             true,
 			},
 			false,
 		},
@@ -130,27 +123,6 @@ func TestNewHealthServiceQuery(t *testing.T) {
 				name:                    "name",
 				near:                    "near",
 				deprecatedTag:           "tag",
-				passingOnly:             true,
-			},
-			false,
-		},
-		{
-			"name_status",
-			"name|any",
-			&HealthServiceQuery{
-				deprecatedStatusFilters: []string{"any"},
-				name:                    "name",
-				passingOnly:             false,
-			},
-			false,
-		},
-		{
-			"name_multi_status",
-			"name|critical,passing",
-			&HealthServiceQuery{
-				deprecatedStatusFilters: []string{"critical", "passing"},
-				name:                    "name",
-				passingOnly:             false,
 			},
 			false,
 		},
@@ -184,7 +156,6 @@ func TestNewHealthServiceQuery(t *testing.T) {
 			deprecatedStatusFilters: []string{"passing"},
 			name:                    "name",
 			connect:                 true,
-			passingOnly:             true,
 		}
 
 		assert.Equal(t, exp, act)
@@ -525,46 +496,46 @@ func TestNewHealthServiceQueryV1(t *testing.T) {
 			"no opts",
 			[]string{},
 			&HealthServiceQuery{
-				name:        "name",
-				passingOnly: true,
+				name:   "name",
+				filter: `Checks.Status == "passing"`,
 			},
 			false,
 		}, {
 			"dc",
 			[]string{"dc=dc"},
 			&HealthServiceQuery{
-				name:        "name",
-				dc:          "dc",
-				passingOnly: true,
+				name:   "name",
+				dc:     "dc",
+				filter: `Checks.Status == "passing"`,
 			},
 			false,
 		}, {
 			"near",
 			[]string{"near=near"},
 			&HealthServiceQuery{
-				name:        "name",
-				near:        "near",
-				passingOnly: true,
+				name:   "name",
+				near:   "near",
+				filter: `Checks.Status == "passing"`,
 			},
 			false,
 		}, {
 			"namespace",
 			[]string{"ns=ns"},
 			&HealthServiceQuery{
-				name:        "name",
-				ns:          "ns",
-				passingOnly: true,
+				name:   "name",
+				ns:     "ns",
+				filter: `Checks.Status == "passing"`,
 			},
 			false,
 		}, {
 			"multiple queries",
 			[]string{"ns=ns", "dc=dc", "near=near"},
 			&HealthServiceQuery{
-				name:        "name",
-				dc:          "dc",
-				near:        "near",
-				ns:          "ns",
-				passingOnly: true,
+				name:   "name",
+				dc:     "dc",
+				near:   "near",
+				ns:     "ns",
+				filter: `Checks.Status == "passing"`,
 			},
 			false,
 		}, {
@@ -595,10 +566,9 @@ func TestNewHealthServiceQueryV1(t *testing.T) {
 			"query and filter",
 			[]string{"dc=dc", "\"my-tag\" in Service.Tags", "\"another-tag\" in Service.Tags"},
 			&HealthServiceQuery{
-				name:        "name",
-				dc:          "dc",
-				filter:      "\"my-tag\" in Service.Tags and \"another-tag\" in Service.Tags",
-				passingOnly: true,
+				name:   "name",
+				dc:     "dc",
+				filter: "\"my-tag\" in Service.Tags and \"another-tag\" in Service.Tags and Checks.Status == \"passing\"",
 			},
 			false,
 		}, {
@@ -644,9 +614,9 @@ func TestNewHealthServiceQueryV1(t *testing.T) {
 			act.stopCh = nil
 		}
 		exp := &HealthServiceQuery{
-			name:        "name",
-			connect:     true,
-			passingOnly: true,
+			filter:  "Checks.Status == \"passing\"",
+			name:    "name",
+			connect: true,
 		}
 
 		assert.NoError(t, err)
@@ -665,19 +635,19 @@ func TestHealthServiceQueryV1_String(t *testing.T) {
 		{
 			"name",
 			[]string{},
-			`health.service(name)`,
+			`health.service(name?filter=Checks.Status == "passing")`,
 		}, {
 			"dc",
 			[]string{"dc=dc"},
-			`health.service(name@dc)`,
+			`health.service(name@dc?filter=Checks.Status == "passing")`,
 		}, {
 			"near",
 			[]string{"near=agent"},
-			`health.service(name~agent)`,
+			`health.service(name~agent?filter=Checks.Status == "passing")`,
 		}, {
 			"ns",
 			[]string{"ns=ns"},
-			`health.service(name?ns=ns)`,
+			`health.service(name?ns=ns&filter=Checks.Status == "passing")`,
 		}, {
 			"multifilter",
 			[]string{"Checks.Status != passing", "mytag in Service.Tags"},
@@ -693,160 +663,5 @@ func TestHealthServiceQueryV1_String(t *testing.T) {
 			}
 			assert.Equal(t, tc.exp, d.String())
 		})
-	}
-}
-
-func TestHealthServiceQueryV1_Fetch(t *testing.T) {
-	t.Parallel()
-
-	criticalService := &dep.HealthService{
-		Node:           testConsul.Config.NodeName,
-		NodeAddress:    testConsul.Config.Bind,
-		NodeDatacenter: "dc1",
-		NodeTaggedAddresses: map[string]string{
-			"lan": "127.0.0.1",
-			"wan": "127.0.0.1",
-		},
-		NodeMeta: map[string]string{
-			"consul-network-segment": "",
-		},
-		ServiceMeta: map[string]string{},
-		Address:     testConsul.Config.Bind,
-		ID:          "critical-service",
-		Name:        "critical-service",
-		Tags:        []string{},
-		Status:      "critical",
-		Weights: api.AgentWeights{
-			Passing: 1,
-			Warning: 1,
-		},
-		Namespace: "",
-	}
-
-	cases := []struct {
-		name        string
-		serviceName string
-		opts        []string
-		exp         []*dep.HealthService
-	}{
-		{
-			"default to returning service instances that are overall passing",
-			"critical-service",
-			[]string{},
-			[]*dep.HealthService{},
-		},
-		{
-			"Checks.Status filter",
-			"critical-service",
-			[]string{"Checks.Status == critical"},
-			[]*dep.HealthService{criticalService},
-		},
-		{
-			// Demonstrates overall status v. check.status behavior
-			"Checks.Status filters services instances by any check with status==passing",
-			"critical-service",
-			[]string{"Checks.Status == passing"},
-			// critical-service has a passing node check and therefore satisfies
-			// this check.status filter even though it is overall critical
-			[]*dep.HealthService{criticalService},
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(fmt.Sprintf(tc.name), func(t *testing.T) {
-			d, err := NewHealthServiceQueryV1(tc.serviceName, tc.opts)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			act, _, err := d.Fetch(testClients)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			if act != nil {
-				for _, v := range act.([]*dep.HealthService) {
-					v.NodeID = ""
-					v.Checks = nil
-					// delete any version data from ServiceMeta
-					v.ServiceMeta = filterMeta(v.ServiceMeta)
-					v.NodeTaggedAddresses = filterAddresses(
-						v.NodeTaggedAddresses)
-				}
-			}
-
-			assert.Equal(t, tc.exp, act)
-		})
-	}
-}
-
-func Test_acceptStatus(t *testing.T) {
-	t.Parallel()
-
-	cases := []struct {
-		name     string
-		filters  []string
-		statuses map[string]bool
-	}{
-		{
-			"no filters",
-			[]string{},
-			map[string]bool{
-				HealthPassing:  true,
-				HealthWarning:  true,
-				HealthCritical: true,
-				HealthMaint:    true,
-			},
-		},
-		{
-			"any filter",
-			[]string{HealthAny},
-			map[string]bool{
-				HealthPassing:  true,
-				HealthWarning:  true,
-				HealthCritical: true,
-				HealthMaint:    true,
-			},
-		},
-		{
-			"passing filter",
-			[]string{HealthPassing},
-			map[string]bool{
-				HealthPassing:  true,
-				HealthWarning:  false,
-				HealthCritical: false,
-				HealthMaint:    false,
-			},
-		},
-		{
-			"critical filter",
-			[]string{HealthCritical},
-			map[string]bool{
-				HealthPassing:  false,
-				HealthWarning:  false,
-				HealthCritical: true,
-				HealthMaint:    false,
-			},
-		},
-		{
-			"multi filter",
-			[]string{HealthWarning, HealthMaint},
-			map[string]bool{
-				HealthPassing:  false,
-				HealthWarning:  true,
-				HealthCritical: false,
-				HealthMaint:    true,
-			},
-		},
-	}
-
-	for _, tc := range cases {
-		for status, expected := range tc.statuses {
-			name := fmt.Sprintf("%s_status=%s", tc.name, status)
-			t.Run(name, func(t *testing.T) {
-				actual := acceptStatus(tc.filters, status)
-				assert.Equal(t, expected, actual)
-			})
-		}
 	}
 }


### PR DESCRIPTION
Reverts hashicorp/hcat#72

This fix causes a breaking change for CTS, which we do not want to include in 0.4.1 and will include for 0.5. Reverting this change for a `cts-0.4.1` branch that CTS will point to for the 0.4.1 release