### PR TITLE
Set KVExistsGet to use blocking queries

### DIFF
--- a/internal/dependency/kv_exists_get.go
+++ b/internal/dependency/kv_exists_get.go
@@ -16,6 +16,7 @@ var (
 // KVExistsGetQuery uses a non-blocking query to lookup a single key in the KV store.
 // The query returns whether the key exists and the value of the key if it exists.
 type KVExistsGetQuery struct {
+	BlockingQuery
 	KVExistsQuery
 }
 
@@ -60,8 +61,6 @@ func (d *KVExistsGetQuery) Stop() {
 }
 
 func (d *KVExistsGetQuery) SetOptions(opts QueryOptions) {
-	opts.WaitIndex = 0
-	opts.WaitTime = 0
 	d.opts = opts
 }
 

--- a/internal/dependency/kv_exists_get_test.go
+++ b/internal/dependency/kv_exists_get_test.go
@@ -7,31 +7,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestNewKVExistsGetQuery_NonBlocking(t *testing.T) {
-	q, err := NewKVExistsGetQueryV1("key", []string{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if _, ok := interface{}(q).(BlockingQuery); ok {
-		t.Fatal("should NOT be blocking")
-	}
-}
-
-func TestKVExistsGetQuery_SetOptions(t *testing.T) {
-	q, err := NewKVExistsGetQueryV1("key", []string{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	q.SetOptions(QueryOptions{WaitIndex: 100, WaitTime: 100})
-	// WaitIndex and WaitTime should always be 0 regardless of query options
-	if q.opts.WaitIndex != 0 {
-		t.Fatal("WaitIndex should be 0")
-	}
-	if q.opts.WaitTime != 0 {
-		t.Fatal("WaitTime should be 0")
-	}
-}
-
 type newKVExistsGetCase struct {
 	exp *KVExistsQuery
 	act *KVExistsGetQuery


### PR DESCRIPTION
Turns out unintended behavior with the template hanging was not
related to blocking queries for this dependency. Adding blocking
queries to avoid overloading the consul agent

`KVExistsGet` (blocking) is different than `KVExists` (which is non-blocking) because changes to the key's value matters, including no value when it doesn't exist.