### PR TITLE
Events and logging

### DIFF
--- a/events/events.go
+++ b/events/events.go
@@ -1,0 +1,108 @@
+package events
+
+import "time"
+
+// EventHandler is the interface of the call back function for receiveing events.
+type EventHandler func(Event)
+
+// Event is used to type restrict the Events
+type Event interface {
+	isEvent()
+}
+
+// Trace is useful to see some details of what's going on
+type Trace struct {
+	ID      string
+	Message string
+	event
+}
+
+// BlockingWait means a blocking query was made
+type BlockingWait struct {
+	ID string
+	event
+}
+
+// ServerContacted indicates that the tracked service has been successfully
+// contacted (received a non-error response).
+type ServerContacted struct {
+	ID string
+	event
+}
+
+// ServerError indicates that an tracked service has been contacted but with
+// an error returned.
+type ServerError struct {
+	ID    string
+	Error error
+	event
+}
+
+// ServerTimeout indicates that a call to the server timed out.
+type ServerTimeout struct {
+	ID string
+	event
+}
+
+// RetryAttempt indicates that a tracked call is being retried.
+type RetryAttempt struct {
+	ID      string
+	Attempt int
+	Sleep   time.Duration
+	Error   error
+	event
+}
+
+// MaxRetries indicates that the maximum number of retries has been reached
+// (and failed).
+type MaxRetries struct {
+	ID    string
+	Count int
+	event
+}
+
+// NewData indicates that fresh/new data has been retrieved from the service.
+type NewData struct {
+	ID   string
+	Data interface{}
+	event
+}
+
+// StaleData indicates that the service returned stale (possibly old) data.
+type StaleData struct {
+	ID          string
+	LastContant time.Duration
+	event
+}
+
+// NoNewData indicates that data was retrieved from the service, but that it
+// matches the current data so no change would be triggered.
+type NoNewData struct {
+	ID string
+	event
+}
+
+// TrackStart indicates that a new data point is being tracked.
+type TrackStart struct {
+	ID string
+	event
+}
+
+// TrackStop indicates that a data point is no longer being tracked.
+type TrackStop struct {
+	ID string
+	event
+}
+
+// Not used yet, need an PolllingQuery interface to match on
+// see BlockingQuery for how it should work
+type PollingWait struct {
+	ID       string
+	Duration time.Duration
+	event
+}
+
+// Event interface type fulfillment
+type event struct{}
+
+func (event) isEvent() {}

--- a/events/events_test.go
+++ b/events/events_test.go
@@ -1,0 +1,37 @@
+package events
+
+import (
+	"testing"
+)
+
+var (
+	_ Event = (*Trace)(nil)
+	_ Event = (*BlockingWait)(nil)
+	_ Event = (*ServerContacted)(nil)
+	_ Event = (*ServerError)(nil)
+	_ Event = (*ServerTimeout)(nil)
+	_ Event = (*RetryAttempt)(nil)
+	_ Event = (*MaxRetries)(nil)
+	_ Event = (*NewData)(nil)
+	_ Event = (*StaleData)(nil)
+	_ Event = (*NoNewData)(nil)
+	_ Event = (*TrackStart)(nil)
+	_ Event = (*TrackStop)(nil)
+	_ Event = (*PollingWait)(nil)
+)
+
+func TestEvents(t *testing.T) {
+	var event EventHandler
+	event = func(e Event) {
+		switch e.(type) {
+		case Trace, BlockingWait, ServerContacted, ServerError,
+			ServerTimeout, RetryAttempt, MaxRetries, NewData, StaleData,
+			NoNewData, TrackStart, TrackStop, PollingWait:
+		default:
+			t.Errorf("Bad event type: %T", e)
+		}
+	}
+	event(Trace{})
+	event(MaxRetries{})
+	event(TrackStop{})
+}

--- a/internal/dependency/catalog_datacenters.go
+++ b/internal/dependency/catalog_datacenters.go
@@ -39,11 +39,6 @@ func NewCatalogDatacentersQuery(ignoreFailing bool) (*CatalogDatacentersQuery, e
 func (d *CatalogDatacentersQuery) Fetch(clients dep.Clients) (interface{}, *dep.ResponseMetadata, error) {
 	opts := d.opts.Merge(&QueryOptions{})
 
-	//log.Printf("[TRACE] %s: GET %s", d, &url.URL{
-	//	Path:     "/v1/catalog/datacenters",
-	//	RawQuery: opts.String(),
-	//})
-
 	// This is pretty ghetto, but the datacenters endpoint does not support
 	// blocking queries, so we are going to "fake it until we make it". When we
 	// first query, the LastIndex will be "0", meaning we should immediately
@@ -54,8 +49,6 @@ func (d *CatalogDatacentersQuery) Fetch(clients dep.Clients) (interface{}, *dep.
 	// This is probably okay given the frequency in which datacenters actually
 	// change, but is technically not edge-triggering.
 	if opts.WaitIndex != 0 {
-		//log.Printf("[TRACE] %s: long polling for %s", d, CatalogDatacentersQuerySleepTime)
-
 		select {
 		case <-d.stopCh:
 			return nil, nil, ErrStopped
@@ -83,8 +76,6 @@ func (d *CatalogDatacentersQuery) Fetch(clients dep.Clients) (interface{}, *dep.
 		}
 		result = dcs
 	}
-
-	//log.Printf("[TRACE] %s: returned %d results", d, len(result))
 
 	sort.Strings(result)
 

--- a/internal/dependency/catalog_node.go
+++ b/internal/dependency/catalog_node.go
@@ -65,7 +65,6 @@ func (d *CatalogNodeQuery) Fetch(clients dep.Clients) (interface{}, *dep.Respons
 	name := d.name
 
 	if name == "" {
-		//log.Printf("[TRACE] %s: getting local agent name", d)
 		var err error
 		name, err = clients.Consul().Agent().NodeName()
 		if err != nil {
@@ -73,16 +72,10 @@ func (d *CatalogNodeQuery) Fetch(clients dep.Clients) (interface{}, *dep.Respons
 		}
 	}
 
-	//log.Printf("[TRACE] %s: GET %s", d, &url.URL{
-	//	Path:     "/v1/catalog/node/" + name,
-	//	RawQuery: opts.String(),
-	//})
 	node, qm, err := clients.Consul().Catalog().Node(name, opts.ToConsulOpts())
 	if err != nil {
 		return nil, nil, errors.Wrap(err, d.String())
 	}
-
-	//log.Printf("[TRACE] %s: returned response", d)
 
 	rm := &dep.ResponseMetadata{
 		LastIndex:   qm.LastIndex,
@@ -90,7 +83,6 @@ func (d *CatalogNodeQuery) Fetch(clients dep.Clients) (interface{}, *dep.Respons
 	}
 
 	if node == nil {
-		//log.Printf("[WARN] %s: no node exists with the name %q", d, name)
 		var node dep.CatalogNode
 		return &node, rm, nil
 	}

--- a/internal/dependency/catalog_nodes.go
+++ b/internal/dependency/catalog_nodes.go
@@ -61,16 +61,10 @@ func (d *CatalogNodesQuery) Fetch(clients dep.Clients) (interface{}, *dep.Respon
 		Near:       d.near,
 	})
 
-	//log.Printf("[TRACE] %s: GET %s", d, &url.URL{
-	//	Path:     "/v1/catalog/nodes",
-	//	RawQuery: opts.String(),
-	//})
 	n, qm, err := clients.Consul().Catalog().Nodes(opts.ToConsulOpts())
 	if err != nil {
 		return nil, nil, errors.Wrap(err, d.String())
 	}
-
-	//log.Printf("[TRACE] %s: returned %d results", d, len(n))
 
 	nodes := make([]*dep.Node, 0, len(n))
 	for _, node := range n {

--- a/internal/dependency/catalog_service.go
+++ b/internal/dependency/catalog_service.go
@@ -91,14 +91,11 @@ func (d *CatalogServiceQuery) Fetch(clients dep.Clients) (interface{}, *dep.Resp
 		q.Set("tag", d.tag)
 		u.RawQuery = q.Encode()
 	}
-	//log.Printf("[TRACE] %s: GET %s", d, u)
 
 	entries, qm, err := clients.Consul().Catalog().Service(d.name, d.tag, opts.ToConsulOpts())
 	if err != nil {
 		return nil, nil, errors.Wrap(err, d.String())
 	}
-
-	//log.Printf("[TRACE] %s: returned %d results", d, len(entries))
 
 	var list []*CatalogService
 	for _, s := range entries {

--- a/internal/dependency/catalog_services.go
+++ b/internal/dependency/catalog_services.go
@@ -108,17 +108,10 @@ func (d *CatalogServicesQuery) Fetch(clients dep.Clients) (interface{}, *dep.Res
 	// it does not support the preferred filter option.
 	opts.NodeMeta = d.nodeMeta
 
-	//log.Printf("[TRACE] %s: GET %s", d, &url.URL{
-	//	Path:     "/v1/catalog/services",
-	//	RawQuery: opts.String(),
-	//})
-
 	entries, qm, err := clients.Consul().Catalog().Services(opts)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, d.String())
 	}
-
-	//log.Printf("[TRACE] %s: returned %d results", d, len(entries))
 
 	var catalogServices []*dep.CatalogSnippet
 	for name, tags := range entries {

--- a/internal/dependency/client_set.go
+++ b/internal/dependency/client_set.go
@@ -324,7 +324,6 @@ func newTransport(i *CreateClientInput) (*http.Transport, error) {
 			tlsConfig.InsecureSkipVerify = false
 		}
 		if !i.SSLVerify {
-			//log.Printf("[WARN] (clients) disabling SSL verification")
 			tlsConfig.InsecureSkipVerify = true
 		}
 

--- a/internal/dependency/connect_ca.go
+++ b/internal/dependency/connect_ca.go
@@ -34,19 +34,11 @@ func (d *ConnectCAQuery) Fetch(clients dep.Clients) (
 	}
 
 	opts := d.opts.Merge(nil)
-	//log.Printf("[TRACE] %s: GET %s", d, &url.URL{
-	//	Path:     "/v1/agent/connect/ca/roots",
-	//	RawQuery: opts.String(),
-	//})
-
 	certs, md, err := clients.Consul().Agent().ConnectCARoots(
 		opts.ToConsulOpts())
 	if err != nil {
 		return nil, nil, errors.Wrap(err, d.String())
 	}
-
-	//log.Printf("[TRACE] %s: returned %d results", d, len(certs.Roots))
-	//log.Printf("[TRACE] %s: %#v ", d, md)
 
 	rm := &dep.ResponseMetadata{
 		LastIndex:   md.LastIndex,

--- a/internal/dependency/connect_leaf.go
+++ b/internal/dependency/connect_leaf.go
@@ -38,18 +38,12 @@ func (d *ConnectLeafQuery) Fetch(clients dep.Clients) (
 	default:
 	}
 	opts := d.opts.Merge(nil)
-	//log.Printf("[TRACE] %s: GET %s", d, &url.URL{
-	//	Path:     "/v1/agent/connect/ca/leaf/" + d.service,
-	//	RawQuery: opts.String(),
-	//})
 
 	cert, md, err := clients.Consul().Agent().ConnectCALeaf(d.service,
 		opts.ToConsulOpts())
 	if err != nil {
 		return nil, nil, errors.Wrap(err, d.String())
 	}
-
-	//log.Printf("[TRACE] %s: returned response", d)
 
 	rm := &dep.ResponseMetadata{
 		LastIndex:   md.LastIndex,

--- a/internal/dependency/file.go
+++ b/internal/dependency/file.go
@@ -44,18 +44,14 @@ func NewFileQuery(s string) (*FileQuery, error) {
 // Fetch retrieves this dependency and returns the result or any errors that
 // occur in the process.
 func (d *FileQuery) Fetch(clients dep.Clients) (interface{}, *dep.ResponseMetadata, error) {
-	//log.Printf("[TRACE] %s: READ %s", d, d.path)
 
 	select {
 	case <-d.stopCh:
-		//log.Printf("[TRACE] %s: stopped", d)
 		return "", nil, ErrStopped
 	case r := <-d.watch(d.stat):
 		if r.err != nil {
 			return "", nil, errors.Wrap(r.err, d.String())
 		}
-
-		//log.Printf("[TRACE] %s: reported change", d)
 
 		data, err := ioutil.ReadFile(d.path)
 		if err != nil {

--- a/internal/dependency/health_service.go
+++ b/internal/dependency/health_service.go
@@ -204,11 +204,6 @@ func (d *HealthServiceQuery) Fetch(clients dep.Clients) (interface{}, *dep.Respo
 		Near:       d.near,
 	})
 
-	//log.Printf("[TRACE] %s: GET %s", d, &url.URL{
-	//	Path:     "/v1/health/service/%d"+d.name,
-	//	RawQuery: opts.String(),
-	//})
-
 	nodes := clients.Consul().Health().Service
 	if d.connect {
 		nodes = clients.Consul().Health().Connect
@@ -217,8 +212,6 @@ func (d *HealthServiceQuery) Fetch(clients dep.Clients) (interface{}, *dep.Respo
 	if err != nil {
 		return nil, nil, errors.Wrap(err, d.String())
 	}
-
-	//log.Printf("[TRACE] %s: returned %d results", d, len(entries))
 
 	list := make([]*dep.HealthService, 0, len(entries))
 	for _, entry := range entries {
@@ -258,8 +251,6 @@ func (d *HealthServiceQuery) Fetch(clients dep.Clients) (interface{}, *dep.Respo
 			Namespace: entry.Service.Namespace,
 		})
 	}
-
-	//log.Printf("[TRACE] %s: returned %d results after filtering", d, len(list))
 
 	// Sort unless the user explicitly asked for nearness
 	if d.near == "" {

--- a/internal/dependency/kv_get.go
+++ b/internal/dependency/kv_get.go
@@ -63,11 +63,6 @@ func (d *KVGetQuery) Fetch(clients dep.Clients) (interface{}, *dep.ResponseMetad
 		Namespace:  d.ns,
 	})
 
-	//log.Printf("[TRACE] %s: GET %s", d, &url.URL{
-	//	Path:     "/v1/kv/" + d.key,
-	//	RawQuery: opts.String(),
-	//})
-
 	pair, qm, err := clients.Consul().KV().Get(d.key, opts.ToConsulOpts())
 	if err != nil {
 		return nil, nil, errors.Wrap(err, d.String())
@@ -79,12 +74,10 @@ func (d *KVGetQuery) Fetch(clients dep.Clients) (interface{}, *dep.ResponseMetad
 	}
 
 	if pair == nil {
-		//log.Printf("[TRACE] %s: returned nil", d)
 		return nil, rm, nil
 	}
 
 	value := dep.KvValue(pair.Value)
-	//log.Printf("[TRACE] %s: returned %q", d, value)
 	return value, rm, nil
 }
 

--- a/internal/dependency/kv_keys.go
+++ b/internal/dependency/kv_keys.go
@@ -53,11 +53,6 @@ func (d *KVKeysQuery) Fetch(clients dep.Clients) (interface{}, *dep.ResponseMeta
 		Datacenter: d.dc,
 	})
 
-	//log.Printf("[TRACE] %s: GET %s", d, &url.URL{
-	//	Path:     "/v1/kv/" + d.prefix,
-	//	RawQuery: opts.String(),
-	//})
-
 	list, qm, err := clients.Consul().KV().Keys(d.prefix, "", opts.ToConsulOpts())
 	if err != nil {
 		return nil, nil, errors.Wrap(err, d.String())
@@ -69,8 +64,6 @@ func (d *KVKeysQuery) Fetch(clients dep.Clients) (interface{}, *dep.ResponseMeta
 		v = strings.TrimLeft(v, "/")
 		keys[i] = v
 	}
-
-	//log.Printf("[TRACE] %s: returned %d results", d, len(list))
 
 	rm := &dep.ResponseMetadata{
 		LastIndex:   qm.LastIndex,

--- a/internal/dependency/kv_list.go
+++ b/internal/dependency/kv_list.go
@@ -99,17 +99,10 @@ func (d *KVListQuery) Fetch(clients dep.Clients) (interface{}, *dep.ResponseMeta
 		Namespace:  d.ns,
 	})
 
-	//log.Printf("[TRACE] %s: GET %s", d, &url.URL{
-	//	Path:     "/v1/kv/" + d.prefix,
-	//	RawQuery: opts.String(),
-	//})
-
 	list, qm, err := clients.Consul().KV().List(d.prefix, opts.ToConsulOpts())
 	if err != nil {
 		return nil, nil, errors.Wrap(err, d.String())
 	}
-
-	//log.Printf("[TRACE] %s: returned %d pairs", d, len(list))
 
 	pairs := make([]*dep.KeyPair, 0, len(list))
 	for _, pair := range list {

--- a/internal/dependency/vault_agent_token.go
+++ b/internal/dependency/vault_agent_token.go
@@ -41,18 +41,14 @@ func NewVaultAgentTokenQuery(path string) (*VaultAgentTokenQuery, error) {
 // Fetch retrieves this dependency and returns the result or any errors that
 // occur in the process.
 func (d *VaultAgentTokenQuery) Fetch(clients dep.Clients) (interface{}, *dep.ResponseMetadata, error) {
-	//log.Printf("[TRACE] %s: READ %s", d, d.path)
 
 	select {
 	case <-d.stopCh:
-		//log.Printf("[TRACE] %s: stopped", d)
 		return "", nil, ErrStopped
 	case r := <-d.watch(d.stat):
 		if r.err != nil {
 			return "", nil, errors.Wrap(r.err, d.String())
 		}
-
-		//log.Printf("[TRACE] %s: reported change", d)
 
 		token, err := ioutil.ReadFile(d.path)
 		if err != nil {

--- a/internal/dependency/vault_list.go
+++ b/internal/dependency/vault_list.go
@@ -51,8 +51,6 @@ func (d *VaultListQuery) Fetch(clients dep.Clients) (interface{}, *dep.ResponseM
 	// If this is not the first query, poll to simulate blocking-queries.
 	if opts.WaitIndex != 0 {
 		dur := VaultDefaultLeaseDuration
-		//log.Printf("[TRACE] %s: long polling for %s", d, dur)
-
 		select {
 		case <-d.stopCh:
 			return nil, nil, ErrStopped
@@ -62,10 +60,6 @@ func (d *VaultListQuery) Fetch(clients dep.Clients) (interface{}, *dep.ResponseM
 
 	// If we got this far, we either didn't have a secret to renew, the secret was
 	// not renewable, or the renewal failed, so attempt a fresh list.
-	//log.Printf("[TRACE] %s: LIST %s", d, &url.URL{
-	//	Path:     "/v1/" + d.path,
-	//	RawQuery: opts.String(),
-	//})
 	secret, err := clients.Vault().Logical().List(d.path)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, d.String())
@@ -75,20 +69,17 @@ func (d *VaultListQuery) Fetch(clients dep.Clients) (interface{}, *dep.ResponseM
 
 	// The secret could be nil if it does not exist.
 	if secret == nil || secret.Data == nil {
-		//log.Printf("[TRACE] %s: no data", d)
 		return respWithMetadata(result)
 	}
 
 	// This is a weird thing that happened once...
 	keys, ok := secret.Data["keys"]
 	if !ok {
-		//log.Printf("[TRACE] %s: no keys", d)
 		return respWithMetadata(result)
 	}
 
 	list, ok := keys.([]interface{})
 	if !ok {
-		//log.Printf("[TRACE] %s: not list", d)
 		return nil, nil, fmt.Errorf("%s: unexpected response", d)
 	}
 
@@ -100,8 +91,6 @@ func (d *VaultListQuery) Fetch(clients dep.Clients) (interface{}, *dep.ResponseM
 		result = append(result, typed)
 	}
 	sort.Strings(result)
-
-	//log.Printf("[TRACE] %s: returned %d results", d, len(result))
 
 	return respWithMetadata(result)
 }

--- a/internal/dependency/vault_read.go
+++ b/internal/dependency/vault_read.go
@@ -83,7 +83,6 @@ func (d *VaultReadQuery) Fetch(clients dep.Clients) (interface{}, *dep.ResponseM
 
 	if !vaultSecretRenewable(d.secret) {
 		dur := leaseCheckWait(d.secret)
-		//log.Printf("[TRACE] %s: non-renewable secret, set sleep for %s", d, dur)
 		d.sleepCh <- dur
 	}
 
@@ -94,7 +93,6 @@ func (d *VaultReadQuery) fetchSecret(clients dep.Clients) error {
 	opts := d.opts.Merge(&QueryOptions{})
 	vaultSecret, err := d.readSecret(clients, opts)
 	if err == nil {
-		printVaultWarnings(d, vaultSecret.Warnings)
 		d.vaultSecret = vaultSecret
 		// the cloned secret which will be exposed to the template
 		d.secret = transformSecret(vaultSecret, opts.DefaultLease)
@@ -135,8 +133,6 @@ func (d *VaultReadQuery) readSecret(clients dep.Clients, opts *QueryOptions) (*a
 	if d.isKVv2 == nil {
 		mountPath, isKVv2, err := isKVv2(vaultClient, d.rawPath)
 		if err != nil {
-			//log.Printf("[WARN] %s: failed to check if %s is KVv2, "+
-			//	"assume not: %s", d, d.rawPath, err)
 			isKVv2 = false
 			d.secretPath = d.rawPath
 		} else if isKVv2 {
@@ -147,11 +143,6 @@ func (d *VaultReadQuery) readSecret(clients dep.Clients, opts *QueryOptions) (*a
 		d.isKVv2 = &isKVv2
 	}
 
-	//queryString := d.queryValues.Encode()
-	//log.Printf("[TRACE] %s: GET %s", d, &url.URL{
-	//	Path:     "/v1/" + d.secretPath,
-	//	RawQuery: queryString,
-	//})
 	vaultSecret, err := vaultClient.Logical().ReadWithData(d.secretPath,
 		d.queryValues)
 

--- a/internal/dependency/vault_write.go
+++ b/internal/dependency/vault_write.go
@@ -84,14 +84,12 @@ func (d *VaultWriteQuery) Fetch(clients dep.Clients) (interface{}, *dep.Response
 		return respWithMetadata(d.secret)
 	}
 
-	printVaultWarnings(d, vaultSecret.Warnings)
 	d.vaultSecret = vaultSecret
 	// cloned secret which will be exposed to the template
 	d.secret = transformSecret(vaultSecret, opts.DefaultLease)
 
 	if !vaultSecretRenewable(d.secret) {
 		dur := leaseCheckWait(d.secret)
-		//log.Printf("[TRACE] %s: non-renewable secret, set sleep for %s", d, dur)
 		d.sleepCh <- dur
 	}
 
@@ -140,18 +138,7 @@ func sha1Map(m map[string]interface{}) string {
 	return fmt.Sprintf("%.4x", h.Sum(nil))
 }
 
-func (d *VaultWriteQuery) printWarnings(warnings []string) {
-	//	for _, w := range warnings {
-	//		//log.Printf("[WARN] %s: %s", d, w)
-	//	}
-}
-
 func (d *VaultWriteQuery) writeSecret(clients dep.Clients, opts *QueryOptions) (*api.Secret, error) {
-	//log.Printf("[TRACE] %s: PUT %s", d, &url.URL{
-	//	Path:     "/v1/" + d.path,
-	//	RawQuery: opts.String(),
-	//})
-
 	data := d.data
 
 	_, isv2, _ := isKVv2(clients.Vault(), d.path)

--- a/view.go
+++ b/view.go
@@ -163,12 +163,16 @@ func (v *view) pollingFlag() (alreadyPolling bool, unflag func()) {
 // function is in the middle of a blocking query.
 func (v *view) poll(viewCh chan<- *view, errCh chan<- error) {
 	var retries int
+	v.event(events.TrackStart{ID: v.ID()})
 
-	if alreadyPolling, unflag := v.pollingFlag(); alreadyPolling {
+	alreadyPolling, stoppedPolling := v.pollingFlag()
+	if alreadyPolling {
 		return
-	} else {
-		defer unflag()
 	}
+	defer func() {
+		stoppedPolling()
+		v.event(events.TrackStop{ID: v.ID()})
+	}()
 
 	for {
 		doneCh := make(chan struct{}, 1)
@@ -183,7 +187,6 @@ func (v *view) poll(viewCh chan<- *view, errCh chan<- error) {
 			// have some successful requests
 			retries = 0
 
-			//log.Printf("[TRACE] (view) %s received data", v.dependency)
 			select {
 			case <-v.stopCh:
 				return
@@ -191,16 +194,17 @@ func (v *view) poll(viewCh chan<- *view, errCh chan<- error) {
 			}
 
 		case <-successCh:
-			// We successfully received a non-error response from the server. This
-			// does not mean we have data (that's dataCh's job), but rather this
-			// just resets the counter indicating we communicated successfully. For
-			// example, Consul make have an outage, but when it returns, the view
-			// is unchanged. We have to reset the counter retries, but not update the
-			// actual template.
-			//log.Printf("[TRACE] (view) %s successful contact, resetting retries", v.dependency
+			// We successfully received a non-error response from the server.
+			// This does not mean we have data (that's dataCh's job), but
+			// rather this just resets the counter indicating we communicated
+			// successfully. For example, Consul make have an outage, but when
+			// it returns, the view is unchanged. We have to reset the counter
+			// retries, but not update the actual template.
+			v.event(events.ServerContacted{ID: v.ID()})
 			retries = 0
 			goto WAIT
 		case err := <-fetchErrCh:
+			v.event(events.ServerError{ID: v.ID(), Error: err})
 			var skipRetry bool
 			if strings.Contains(err.Error(), "Unexpected response code: 400") {
 				// 400 is not useful to retry
@@ -221,8 +225,12 @@ func (v *view) poll(viewCh chan<- *view, errCh chan<- error) {
 			if v.retryFunc != nil && !skipRetry {
 				retry, sleep := v.retryFunc(retries)
 				if retry {
-					//log.Printf("[WARN] (view) %s (retry attempt %d after %q)",
-					//err, retries+1, sleep)
+					v.event(events.RetryAttempt{
+						ID:      v.ID(),
+						Attempt: retries + 1,
+						Sleep:   sleep,
+						Error:   err,
+					})
 					select {
 					case <-time.After(sleep):
 						retries++
@@ -231,9 +239,8 @@ func (v *view) poll(viewCh chan<- *view, errCh chan<- error) {
 						return
 					}
 				}
+				v.event(events.MaxRetries{ID: v.ID(), Count: retries})
 			}
-
-			//log.Printf("[ERR] (view) %s (exceeded maximum retries)", err)
 
 			// Push the error back up to the watcher
 			select {
@@ -243,7 +250,6 @@ func (v *view) poll(viewCh chan<- *view, errCh chan<- error) {
 				return
 			}
 		case <-v.stopCh:
-			//log.Printf("[TRACE] (view) %s stopping poll (received on view stopCh)", v.dependency)
 			return
 		}
 	}
@@ -255,7 +261,7 @@ func (v *view) poll(viewCh chan<- *view, errCh chan<- error) {
 // result of doneCh and errCh. It is assumed that only one instance of fetch
 // is running per view and therefore no locking or mutexes are used.
 func (v *view) fetch(doneCh, successCh chan<- struct{}, errCh chan<- error) {
-	//log.Printf("[TRACE] (view) %s starting fetch", v.dependency)
+	v.event(events.Trace{ID: v.ID(), Message: "starting fetch"})
 
 	var allowStale bool
 	if v.maxStale != 0 {
@@ -285,14 +291,15 @@ func (v *view) fetch(doneCh, successCh chan<- struct{}, errCh chan<- error) {
 			opts = opts.SetContext(v.ctx)
 			d.SetOptions(opts)
 		}
+		v.event(events.Trace{ID: v.ID(), Message: "fetching value"})
 		data, rm, err := v.dependency.Fetch(v.clients)
 		if err != nil {
 			switch {
 			case err == dep.ErrStopped:
-				//log.Printf("[TRACE] (view) %s reported stop", v.dependency)
+				v.event(events.Trace{ID: v.ID(), Message: err.Error()})
 			case strings.Contains(err.Error(), context.Canceled.Error()):
 				// This is a wrapped error so relying on string matching
-				// log.Printf("[TRACE] (view) %s request context stopped", v.dependency)
+				v.event(events.Trace{ID: v.ID(), Message: err.Error()})
 			default:
 				errCh <- err
 			}
@@ -308,7 +315,7 @@ func (v *view) fetch(doneCh, successCh chan<- struct{}, errCh chan<- error) {
 		// If we got this far, we received data successfully. That data might not
 		// trigger a data update (because we could continue below), but we need to
 		// inform the poller to reset the retry count.
-		//log.Printf("[TRACE] (view) %s marking successful data response", v.dependency)
+		v.event(events.Trace{ID: v.ID(), Message: "successful data response"})
 		select {
 		case successCh <- struct{}{}:
 		default:
@@ -316,7 +323,7 @@ func (v *view) fetch(doneCh, successCh chan<- struct{}, errCh chan<- error) {
 
 		if allowStale && rm.LastContact > v.maxStale {
 			allowStale = false
-			//log.Printf("[TRACE] (view) %s stale data (last contact exceeded max_stale)", v.dependency)
+			v.event(events.StaleData{ID: v.ID(), LastContant: rm.LastContact})
 			continue
 		}
 
@@ -329,13 +336,14 @@ func (v *view) fetch(doneCh, successCh chan<- struct{}, errCh chan<- error) {
 		}
 
 		if rm.LastIndex == v.lastIndex {
-			//log.Printf("[TRACE] (view) %s no new data (index was the same)", v.dependency)
+			v.event(events.Trace{ID: v.ID(), Message: "same index, no new data"})
 			continue
 		}
 
 		v.dataLock.Lock()
 		if rm.LastIndex < v.lastIndex {
-			//log.Printf("[TRACE] (view) %s had a lower index, resetting", v.dependency)
+			v.event(events.Trace{ID: v.ID(),
+				Message: "wrong index order, resetting"})
 			v.lastIndex = 0
 			v.dataLock.Unlock()
 			continue
@@ -343,18 +351,19 @@ func (v *view) fetch(doneCh, successCh chan<- struct{}, errCh chan<- error) {
 		v.lastIndex = rm.LastIndex
 
 		if v.receivedData && reflect.DeepEqual(data, v.data) {
-			//log.Printf("[TRACE] (view) %s no new data (contents were the same)", v.dependency)
+			v.event(events.NoNewData{ID: v.ID()})
 			v.dataLock.Unlock()
 			continue
 		}
 
 		if _, ok := v.dependency.(idep.BlockingQuery); ok && data == nil {
-			//log.Printf("[TRACE] (view) %s asked for blocking query", v.dependency)
+			v.event(events.BlockingWait{ID: v.ID()})
 			v.dataLock.Unlock()
 			continue
 		}
 		v.dataLock.Unlock()
 
+		v.event(events.NewData{ID: v.ID(), Data: data})
 		v.store(data)
 
 		close(doneCh)


### PR DESCRIPTION
Adds a EventHandler callback hook and Event types to allow hashicat to provide the application some feedback on it's workings. This adds the initial callback hook along with the set of possible Event types to type match on and pull additional data from for your logs or whatever.

Broken into 3 commits. First (oldest) adds the support, second converts/adds the event calls to the callback, the 3rd only removes a bunch of logging that isn't being converted. All events now come from the view or watcher, the logging calls on the dependencies were either generalized and added to the view or removed.

Resolves #68 