### PR TITLE
consul-template nil pointer fix port

### DIFF
--- a/tfunc/consul_v0.go
+++ b/tfunc/consul_v0.go
@@ -166,7 +166,7 @@ func lsFunc(emptyIsSafe bool) func(hcat.Recaller) interface{} {
 
 // nodeFunc returns or accumulates catalog node dependency.
 func nodeFunc(recall hcat.Recaller) interface{} {
-	return func(s ...string) (*dep.CatalogNode, error) {
+	return func(s ...string) (interface{}, error) {
 
 		d, err := idep.NewCatalogNodeQuery(strings.Join(s, ""))
 		if err != nil {
@@ -275,7 +275,7 @@ func connectCARootsFunc(recall hcat.Recaller) interface{} {
 
 // connectLeafFunc returns leaf certificate representing a single service.
 func connectLeafFunc(recall hcat.Recaller) interface{} {
-	return func(s ...string) (*api.LeafCert, error) {
+	return func(s ...string) (interface{}, error) {
 		if len(s) == 0 || s[0] == "" {
 			return nil, nil
 		}

--- a/tfunc/consul_v0_test.go
+++ b/tfunc/consul_v0_test.go
@@ -183,6 +183,17 @@ func TestConsulV0Execute(t *testing.T) {
 			false,
 		},
 		{
+			"func_node_nil_pointer_evaluation",
+			hcat.TemplateInput{
+				Contents: `{{ $v := node }}{{ $v.Node }}`,
+			},
+			func() hcat.Watcherer {
+				return fakeWatcher{hcat.NewStore()}
+			}(),
+			"<no value>",
+			false,
+		},
+		{
 			"func_nodes",
 			hcat.TemplateInput{
 				Contents: `{{ range nodes }}{{ .Node }}{{ end }}`,
@@ -317,6 +328,17 @@ func TestConsulV0Execute(t *testing.T) {
 				return fakeWatcher{st}
 			}(),
 			"PEMKEY",
+			false,
+		},
+		{
+			"leaf_cert_nil_pointer_evaluation",
+			hcat.TemplateInput{
+				Contents: `{{ $v := caLeaf "foo" }}{{ $v.CertPEM }}`,
+			},
+			func() hcat.Watcherer {
+				return fakeWatcher{hcat.NewStore()}
+			}(),
+			"<no value>",
 			false,
 		},
 		{

--- a/tfunc/vault.go
+++ b/tfunc/vault.go
@@ -11,11 +11,9 @@ import (
 
 // secretFunc returns or accumulates secret dependencies from Vault.
 func secretFunc(recall hcat.Recaller) interface{} {
-	return func(s ...string) (*dep.Secret, error) {
-		var result *dep.Secret
-
+	return func(s ...string) (interface{}, error) {
 		if len(s) == 0 {
-			return result, nil
+			return nil, nil
 		}
 
 		path, rest := s[0], s[1:]
@@ -26,7 +24,7 @@ func secretFunc(recall hcat.Recaller) interface{} {
 			}
 			parts := strings.SplitN(str, "=", 2)
 			if len(parts) != 2 {
-				return result, fmt.Errorf("not k=v pair %q", str)
+				return nil, fmt.Errorf("not k=v pair %q", str)
 			}
 
 			k, v := strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1])
@@ -48,11 +46,10 @@ func secretFunc(recall hcat.Recaller) interface{} {
 		}
 
 		if value, ok := recall(d); ok {
-			result = value.(*dep.Secret)
-			return result, nil
+			return value.(*dep.Secret), nil
 		}
 
-		return result, nil
+		return nil, nil
 	}
 }
 

--- a/tfunc/vault_test.go
+++ b/tfunc/vault_test.go
@@ -278,6 +278,17 @@ func TestVaultExecute(t *testing.T) {
 			"",
 			false,
 		},
+		{
+			"func_secret_nil_pointer_evaluation",
+			hcat.TemplateInput{
+				Contents: `{{ $v := secret "secret/foo" }}{{ $v.Data.zip }}`,
+			},
+			func() hcat.Watcherer {
+				return fakeWatcher{hcat.NewStore()}
+			}(),
+			"<no value>",
+			false,
+		},
 	}
 
 	for i, tc := range cases {


### PR DESCRIPTION
ports over a fix to the template functions; node, caLeaf and secret

They have an error condition returning the typed nil pointer that would break templates using a $variable.

Consul-template fix PR: https://github.com/hashicorp/consul-template/pull/1535