### PR TITLE
Add new watcher method to continuously update data

### DIFF
--- a/watcher.go
+++ b/watcher.go
@@ -260,7 +260,6 @@ func (w *Watcher) Wait(ctx context.Context) error {
 // should be called at given time and should not be called with Wait.
 func (w *Watcher) Watch(ctx context.Context, tmplCh chan string) error {
 	w.stopCh.drain()
-	go func() { w.waitingCh <- struct{}{} }()
 
 	dataUpdateAndNotify := func(v *view) {
 		id := v.ID()


### PR DESCRIPTION
The watcher method also sends template IDs to the caller for
async template processing.