### PR TITLE
Replace deprecated 'circleci/golang' with 'cimg/go' image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,8 +6,7 @@ jobs:
       CONSUL_VERSION: 1.8.0
       VAULT_VERSION: 1.4.2
     docker:
-      - image: docker.mirror.hashicorp.services/circleci/golang:latest
-    working_directory: /go/src/github.com/hashicorp/hcat
+      - image: docker.mirror.hashicorp.services/cimg/go:1.17
     steps:
       - checkout
       - restore_cache:


### PR DESCRIPTION
Context for deprecating 'circleci/golang':
https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034

cimg/go currently doesn't support a `latest` tag. Substituted with `1.17` tag to
get latest version of of golang for now. https://hub.docker.com/r/cimg/go/tags?page=1

Removed working_dir:
 - Reason: This was causing circleci error: "mkdir: cannot create directory
 ‘/go’: Permission denied"
 - Solution: Referred to Consul PR for this fix. The working_dir is redundant
