### PR TITLE
Not dirty should not mean complete

### DIFF
--- a/watcher.go
+++ b/watcher.go
@@ -619,7 +619,7 @@ func (t *tracker) notifiersFor(view IDer) []Notifier {
 func (t *tracker) complete(notifier IDer) bool {
 	for _, tp := range t.tracked {
 		thisNotifier := tp.notify == notifier.ID()
-		if thisNotifier && tp.inUse && !tp.cacheAccessed {
+		if thisNotifier && !tp.cacheAccessed {
 			return false
 		}
 	}

--- a/watcher_test.go
+++ b/watcher_test.go
@@ -785,7 +785,7 @@ func TestWatcherMarkSweep(t *testing.T) {
 		// everything watched
 		checkDeps(fdep, bdep)
 		// marks all dependencies of this notifier as being unused
-		w.Mark(n)
+		w.MarkForSweep(n)
 		// everything still watched
 		checkDeps(fdep, bdep)
 


### PR DESCRIPTION
Fixes a bug where there are unresolved dependencies but they don't count against complete as they haven't been marked in use yet by the mark-n-sweep tracker.. which shouldn't have been used for this.

Note discovered this bug while working on the doc_test examples.