### PR TITLE
Update examples

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -11,15 +11,15 @@ import (
 )
 
 var (
-	runExamples = flag.Bool("egs", false, "Run example tests")
-	consuladdr  string
+	RunExamples = flag.Bool("egs", false, "Run example tests")
+	Consuladdr  string
 )
 
 func TestMain(m *testing.M) {
 	flag.Parse()
 	cleanup := func() {}
-	if *runExamples {
-		consuladdr, cleanup = testConsulSetup()
+	if *RunExamples {
+		Consuladdr, cleanup = testConsulSetup()
 	}
 	retCode := m.Run()
 	cleanup() // can't defer w/ os.Exit


### PR DESCRIPTION
Updating the examples in doc_test.go for API changes.

Converted them to blackbox tests as well to make them better examples and eliminate circular dependency issues with updates.