### PR TITLE
Buffer period rework

### DIFF
--- a/buffer_period.go
+++ b/buffer_period.go
@@ -132,8 +132,7 @@ func (t *timer) stop() {
 	}
 }
 
-// tick updates the minimum buffer timer and returns whether the timer
-// was active.
+// tick updates the minimum buffer timer
 func (t *timer) tick() {
 	now := time.Now()
 

--- a/buffer_period.go
+++ b/buffer_period.go
@@ -79,31 +79,30 @@ func (t *timers) Add(min, max time.Duration, id string) bool {
 }
 
 // Buffered checks the cache of recently expired timers if the timer is done
-// buffering.
+// buffering. (used in testing)
 func (t *timers) Buffered(id string) bool {
 	t.mux.RLock()
 	defer t.mux.RUnlock()
 	return t.buffered[id]
 }
 
-// Buffer activates the buffer period and updates the timer. Returns whether
-// the buffer is already active.
-func (t *timers) Buffer(id string) bool {
+// isBuffering tests whether buffing is currently in use
+func (t *timers) isBuffering(id string) bool {
+	_, ok := t.timers[id]
+	return ok
+}
+
+// tick activates the buffer period and updates the timer.
+// Returns false if no timer is found.
+func (t *timers) tick(id string) bool {
 	t.mux.Lock()
 	defer t.mux.Unlock()
 
-	if t.buffered[id] {
-		// Buffer is being reactivated, remove it from the cache because it's no
-		// longer considered ready.
-		delete(t.buffered, id)
-		return false
-	}
-
 	timer, ok := t.timers[id]
 	if ok {
-		return timer.tick()
+		timer.tick()
 	}
-	return false
+	return ok
 }
 
 // Reset resets an active timer
@@ -135,16 +134,14 @@ func (t *timer) stop() {
 
 // tick updates the minimum buffer timer and returns whether the timer
 // was active.
-func (t *timer) tick() bool {
+func (t *timer) tick() {
 	now := time.Now()
 
 	if t.active() {
 		t.activeTick(now)
-		return true
 	}
 
 	t.inactiveTick(now)
-	return false
 }
 
 func (t *timer) active() bool {

--- a/resolver.go
+++ b/resolver.go
@@ -28,7 +28,7 @@ func NewResolver() *Resolver {
 // Watcherer is the subset of the Watcher's API that the resolver needs.
 // The interface is used to make the used/required API explicit.
 type Watcherer interface {
-	Buffer(Notifier) bool
+	Buffering(Notifier) bool
 	Recaller(Notifier) Recaller
 	Complete(Notifier) bool
 }
@@ -44,12 +44,6 @@ type Templater interface {
 // output returns Complete as true. It uses the watcher for dependency
 // lookup state. The content will be updated each pass until complete.
 func (r *Resolver) Run(tmpl Templater, w Watcherer) (ResolveEvent, error) {
-
-	// Check if this dependency has any dependencies that have been change and
-	// if not, don't waste time re-rendering it.
-	if w.Buffer(tmpl) {
-		return ResolveEvent{Complete: false}, nil
-	}
 
 	// If Watcherer supports it, wrap the template call with the Mark-n-Sweep
 	// garbage collector to stop and dereference the old/unused views.

--- a/store.go
+++ b/store.go
@@ -1,6 +1,7 @@
 package hcat
 
 import (
+	r "reflect"
 	"sync"
 )
 
@@ -29,6 +30,21 @@ func (s *Store) Save(id string, data interface{}) {
 	s.Lock()
 	defer s.Unlock()
 
+	if _, ok := s.data[id]; ok {
+		s.data[id] = data
+		return
+	}
+	// only write initial value if valid/non-empty/non-nil
+	v := r.ValueOf(data)
+	if !v.IsValid() || v.IsZero() {
+		return
+	}
+	switch v.Kind() {
+	case r.Chan, r.Func, r.Interface, r.Ptr, r.Slice:
+		if v.IsNil() {
+			return
+		}
+	}
 	s.data[id] = data
 }
 

--- a/template_test.go
+++ b/template_test.go
@@ -229,7 +229,7 @@ type fakeWatcher struct {
 	*Store
 }
 
-func (fakeWatcher) Buffer(string) bool       { return false }
+func (fakeWatcher) Buffering(string) bool    { return false }
 func (f fakeWatcher) Complete(Notifier) bool { return true }
 func (f fakeWatcher) Mark(Notifier)          {}
 func (f fakeWatcher) Sweep(Notifier)         {}

--- a/tfunc/tfunc_test.go
+++ b/tfunc/tfunc_test.go
@@ -60,7 +60,7 @@ type fakeWatcher struct {
 	*hcat.Store
 }
 
-func (fakeWatcher) Buffer(hcat.Notifier) bool     { return false }
+func (fakeWatcher) Buffering(hcat.Notifier) bool  { return false }
 func (f fakeWatcher) Complete(hcat.Notifier) bool { return true }
 func (f fakeWatcher) Recaller(hcat.Notifier) hcat.Recaller {
 	return func(d dep.Dependency) (value interface{}, found bool) {

--- a/view.go
+++ b/view.go
@@ -376,13 +376,15 @@ func (v *view) fetch(doneCh, successCh chan<- struct{}, errCh chan<- error) {
 }
 
 // Store-s the data and marks that it was received
-func (v *view) store(data interface{}) {
+// Returns the view to make test setup easier.
+func (v *view) store(data interface{}) *view {
 	v.dataLock.Lock()
 	defer v.dataLock.Unlock()
 	v.data = data
 	if !v.receivedData {
 		v.receivedData = true
 	}
+	return v
 }
 
 const minDelayBetweenUpdates = time.Millisecond * 100

--- a/watcher.go
+++ b/watcher.go
@@ -331,8 +331,8 @@ func (w *Watcher) Watch(ctx context.Context, tmplCh chan string) error {
 // configured for the template, it will skip the buffering.
 // period.
 func (w *Watcher) Buffering(n Notifier) bool {
-	// add '&& w.Complete(n)' below to enable buffering only after the
-	// notifier/template has been completely evaluated/rendered.
+	// to enable buffering only after the notifier/template has been completely
+	// evaluated/rendered, you need to add '&& w.Complete(n)' to the line below
 	if w.bufferTemplates.isBuffering(n.ID()) {
 		w.bufferTemplates.tick(n.ID())
 		return true

--- a/watcher.go
+++ b/watcher.go
@@ -198,7 +198,7 @@ func (w *Watcher) Wait(ctx context.Context) error {
 		id := v.ID()
 		w.cache.Save(id, v.Data())
 		for _, n := range w.tracker.notifiersFor(v) {
-			if n.Notify(v.Data()) {
+			if n.Notify(v.Data()) && !w.Buffering(n) {
 				notify = true
 			}
 		}
@@ -207,6 +207,7 @@ func (w *Watcher) Wait(ctx context.Context) error {
 	for {
 		select {
 		case view := <-w.dataCh:
+			// this case (<-w.dataCh) only happens if there is new/udpated data
 			notify := dataUpdate(view)
 			// Drain all dependency data. Prevents re-rendering templates over
 			// and over when a large batch of dependencies are updated.
@@ -271,7 +272,7 @@ func (w *Watcher) Watch(ctx context.Context, tmplCh chan string) error {
 		id := v.ID()
 		w.cache.Save(id, v.Data())
 		for _, n := range w.tracker.notifiersFor(v) {
-			if n.Notify(v.Data()) {
+			if n.Notify(v.Data()) && !w.Buffering(n) {
 				tmplCh <- n.ID()
 			}
 		}
@@ -325,15 +326,18 @@ func (w *Watcher) Watch(ctx context.Context, tmplCh chan string) error {
 	}
 }
 
-// Buffer sets the template to activate buffer and accumulate changes for a
+// Buffering sets the template to activate buffer and accumulate changes for a
 // period. If the template has not been initalized or a buffer period is not
-// configured for the template, it will skip buffering.
-func (w *Watcher) Buffer(n Notifier) bool {
-	// first pass skips buffering.
-	if !w.tracker.notifierTracked(n) {
-		return false
+// configured for the template, it will skip the buffering.
+// period.
+func (w *Watcher) Buffering(n Notifier) bool {
+	// add '&& w.Complete(n)' below to enable buffering only after the
+	// notifier/template has been completely evaluated/rendered.
+	if w.bufferTemplates.isBuffering(n.ID()) {
+		w.bufferTemplates.tick(n.ID())
+		return true
 	}
-	return w.bufferTemplates.Buffer(n.ID())
+	return false
 }
 
 // BufferReset resets an active buffer period to inactive.
@@ -403,6 +407,7 @@ func (w *Watcher) Poll(deps ...dep.Dependency) {
 	}
 	for _, d := range deps {
 		if v := w.tracker.view(d.ID()); v != nil {
+			// view.poll checks if it is already polling
 			go v.poll(w.dataCh, w.errCh)
 		}
 	}
@@ -689,7 +694,8 @@ func (t *tracker) notifiersFor(view IDer) []Notifier {
 func (t *tracker) complete(notifier IDer) bool {
 	for _, tp := range t.tracked {
 		thisNotifier := tp.notify == notifier.ID()
-		if thisNotifier && !tp.cacheAccessed {
+		cacheNotAccessed := !tp.cacheAccessed
+		if thisNotifier && cacheNotAccessed {
 			return false
 		}
 	}

--- a/watcher_test.go
+++ b/watcher_test.go
@@ -769,8 +769,8 @@ func TestWatcherWatch(t *testing.T) {
 			}, {
 				"multiple",
 				func(w *Watcher, n Notifier, d dep.Dependency) {
-					// Emulate multiple changes but expect 2 notifications within max
-					// buffer delay
+					// Emulate multiple changes but still expect just a single
+					// notifications within max buffer delay
 					w.dataCh <- w.track(n, d)
 					w.Buffering(n)
 					w.Buffering(n)


### PR DESCRIPTION
Fixes a bug with endless buffer triggers if you call resolver.Run with a template that hasn't updated.

Ties the buffer period to only be triggered by data updates instead of being tied to template resolver runs.

Buffering is now always on once enabled (used to be skipped on first run).

Broken down into 3 commits. The logic changes, test fixes, new tests. Probably easier to review if you look at the separate commits.