### PR TITLE
watcher Wait/Watch refactor to reuse common logic

### DIFF
--- a/watcher_test.go
+++ b/watcher_test.go
@@ -102,7 +102,7 @@ func TestWatcherRegister(t *testing.T) {
 		if err := w.Register(tt); err != nil {
 			t.Fatal("error should be nil, got:", err)
 		}
-		if err := w.Register(tt); err != RegistryErr {
+		if err := w.Register(tt); err != ErrRegistry {
 			t.Fatal("should have errored")
 		}
 	})


### PR DESCRIPTION
Now that these have stablized, wanted to eliminate the duplicate code. This separates out the select's waiting on an event (into a private method) which return the list of notifiers (and an error) for the wrapping methods to act on.