### PR TITLE
Method for validating a template's dependency requests

### DIFF
--- a/resolver_test.go
+++ b/resolver_test.go
@@ -426,6 +426,27 @@ func timedEchoTemplate(data string) *Template {
 		})
 }
 
+func errorFunc(recall Recaller) interface{} {
+	return func(recall Recaller) interface{} {
+		return func(s string) error {
+			d := &idep.FakeDepFetchError{Name: s}
+			_, _, err := recall(d)
+			if err != nil {
+				return err
+			}
+			return nil
+		}
+	}
+}
+
+func errorTemplate(data string) *Template {
+	return NewTemplate(
+		TemplateInput{
+			Contents:     `{{testErr "` + data + `"}} `,
+			FuncMapMerge: template.FuncMap{"testErr": errorFunc},
+		})
+}
+
 // watcher with no Looker
 func blindWatcher() *Watcher {
 	return NewWatcher(WatcherInput{Cache: NewStore()})

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -360,7 +360,7 @@ func echoTemplate(data string) *Template {
 func echoFunc(recall Recaller) interface{} {
 	return func(s string) interface{} {
 		d := &idep.FakeDep{Name: s}
-		if value, ok := recall(d); ok {
+		if value, ok, _ := recall(d); ok {
 			if value == nil {
 				return ""
 			}
@@ -376,7 +376,7 @@ func wordListFunc(recall Recaller) interface{} {
 			Name: "words",
 			Data: s,
 		}
-		if value, ok := recall(d); ok {
+		if value, ok, _ := recall(d); ok {
 			if value == nil {
 				return []string{}
 			}
@@ -401,7 +401,7 @@ func timedEchoFunc(delay time.Duration) interface{} {
 	return func(recall Recaller) interface{} {
 		return func(s string) interface{} {
 			d := &idep.FakeTimedUpdateDep{Name: s, Delay: delay}
-			if value, ok := recall(d); ok {
+			if value, ok, _ := recall(d); ok {
 				if value == nil {
 					return ""
 				}

--- a/template.go
+++ b/template.go
@@ -68,7 +68,7 @@ type Renderer interface {
 
 // Recaller is the read interface for the cache
 // Implemented by Store and Watcher (which wraps Store)
-type Recaller func(dep.Dependency) (value interface{}, found bool)
+type Recaller func(dep.Dependency) (value interface{}, found bool, err error)
 
 // TemplateInput is used as input when creating the template.
 type TemplateInput struct {

--- a/template_test.go
+++ b/template_test.go
@@ -234,7 +234,8 @@ func (f fakeWatcher) Complete(Notifier) bool { return true }
 func (f fakeWatcher) Mark(Notifier)          {}
 func (f fakeWatcher) Sweep(Notifier)         {}
 func (f fakeWatcher) Recaller(Notifier) Recaller {
-	return func(d dep.Dependency) (value interface{}, found bool) {
-		return f.Store.Recall(d.ID())
+	return func(d dep.Dependency) (value interface{}, found bool, err error) {
+		v, found := f.Store.Recall(d.ID())
+		return v, found, nil
 	}
 }

--- a/tfunc/consul_v0.go
+++ b/tfunc/consul_v0.go
@@ -31,7 +31,11 @@ func datacentersFunc(recall hcat.Recaller) interface{} {
 			return result, err
 		}
 
-		if value, ok := recall(d); ok {
+		value, ok, err := recall(d)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
 			return value.([]string), nil
 		}
 
@@ -51,7 +55,11 @@ func keyFunc(recall hcat.Recaller) interface{} {
 			return "", err
 		}
 
-		if value, ok := recall(d); ok {
+		value, ok, err := recall(d)
+		if err != nil {
+			return "", err
+		}
+		if ok {
 			switch v := value.(type) {
 			case nil:
 				return "", nil
@@ -78,7 +86,11 @@ func keyExistsFunc(recall hcat.Recaller) interface{} {
 			return false, err
 		}
 
-		if value, ok := recall(d); ok {
+		value, ok, err := recall(d)
+		if err != nil {
+			return false, err
+		}
+		if ok {
 			return value != nil, nil
 		}
 
@@ -99,7 +111,11 @@ func keyWithDefaultFunc(recall hcat.Recaller) interface{} {
 			return "", err
 		}
 
-		if value, ok := recall(d); ok {
+		value, ok, err := recall(d)
+		if err != nil {
+			return "", err
+		}
+		if ok {
 			if value == nil || value.(string) == "" {
 				return def, nil
 			}
@@ -134,7 +150,11 @@ func lsFunc(emptyIsSafe bool) func(hcat.Recaller) interface{} {
 			}
 
 			// Only return non-empty top-level keys
-			if value, ok := recall(d); ok {
+			value, ok, err := recall(d)
+			if err != nil {
+				return nil, err
+			}
+			if ok {
 				for _, pair := range value.([]*dep.KeyPair) {
 					if pair.Key != "" && !strings.Contains(pair.Key, "/") {
 						result = append(result, pair)
@@ -173,7 +193,11 @@ func nodeFunc(recall hcat.Recaller) interface{} {
 			return nil, err
 		}
 
-		if value, ok := recall(d); ok {
+		value, ok, err := recall(d)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
 			return value.(*dep.CatalogNode), nil
 		}
 
@@ -191,7 +215,11 @@ func nodesFunc(recall hcat.Recaller) interface{} {
 			return nil, err
 		}
 
-		if value, ok := recall(d); ok {
+		value, ok, err := recall(d)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
 			return value.([]*dep.Node), nil
 		}
 
@@ -213,7 +241,11 @@ func serviceFunc(recall hcat.Recaller) interface{} {
 			return nil, err
 		}
 
-		if value, ok := recall(d); ok {
+		value, ok, err := recall(d)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
 			return value.([]*dep.HealthService), nil
 		}
 
@@ -231,7 +263,11 @@ func servicesFunc(recall hcat.Recaller) interface{} {
 			return nil, err
 		}
 
-		if value, ok := recall(d); ok {
+		value, ok, err := recall(d)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
 			return value.([]*dep.CatalogSnippet), nil
 		}
 
@@ -253,7 +289,11 @@ func connectFunc(recall hcat.Recaller) interface{} {
 			return nil, err
 		}
 
-		if value, ok := recall(d); ok {
+		value, ok, err := recall(d)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
 			return value.([]*dep.HealthService), nil
 		}
 
@@ -266,7 +306,11 @@ func connectFunc(recall hcat.Recaller) interface{} {
 func connectCARootsFunc(recall hcat.Recaller) interface{} {
 	return func(...string) ([]*api.CARoot, error) {
 		d := idep.NewConnectCAQuery()
-		if value, ok := recall(d); ok {
+		value, ok, err := recall(d)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
 			return value.([]*api.CARoot), nil
 		}
 		return nil, nil
@@ -280,7 +324,11 @@ func connectLeafFunc(recall hcat.Recaller) interface{} {
 			return nil, nil
 		}
 		d := idep.NewConnectLeafQuery(s[0])
-		if value, ok := recall(d); ok {
+		value, ok, err := recall(d)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
 			return value.(*api.LeafCert), nil
 		}
 		return nil, nil
@@ -312,7 +360,11 @@ func treeFunc(emptyIsSafe bool) func(hcat.Recaller) interface{} {
 			}
 
 			// Only return non-empty top-level keys
-			if value, ok := recall(d); ok {
+			value, ok, err := recall(d)
+			if err != nil {
+				return nil, err
+			}
+			if ok {
 				for _, pair := range value.([]*dep.KeyPair) {
 					parts := strings.Split(pair.Key, "/")
 					if parts[len(parts)-1] != "" {

--- a/tfunc/consul_v1.go
+++ b/tfunc/consul_v1.go
@@ -53,7 +53,11 @@ func v1ServicesFunc(recall hcat.Recaller) interface{} {
 			return nil, err
 		}
 
-		if value, ok := recall(d); ok {
+		value, ok, err := recall(d)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
 			return value.([]*dep.CatalogSnippet), nil
 		}
 
@@ -78,7 +82,11 @@ func v1ServiceFunc(recall hcat.Recaller) interface{} {
 			return nil, err
 		}
 
-		if value, ok := recall(d); ok {
+		value, ok, err := recall(d)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
 			return value.([]*dep.HealthService), nil
 		}
 
@@ -105,7 +113,11 @@ func v1ConnectFunc(recall hcat.Recaller) interface{} {
 			return nil, err
 		}
 
-		if value, ok := recall(d); ok {
+		value, ok, err := recall(d)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
 			return value.([]*dep.HealthService), nil
 		}
 
@@ -130,7 +142,11 @@ func v1KVListFunc(recall hcat.Recaller) interface{} {
 			return nil, err
 		}
 
-		if value, ok := recall(d); ok {
+		value, ok, err := recall(d)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
 			return value.([]*dep.KeyPair), nil
 		}
 
@@ -155,7 +171,11 @@ func v1KVGetFunc(recall hcat.Recaller) interface{} {
 			return "", err
 		}
 
-		if value, ok := recall(d); ok {
+		value, ok, err := recall(d)
+		if err != nil {
+			return "", err
+		}
+		if ok {
 			return value.(dep.KvValue), nil
 		}
 
@@ -180,7 +200,11 @@ func v1KVExistsFunc(recall hcat.Recaller) interface{} {
 			return dep.KVExists(false), err
 		}
 
-		if value, ok := recall(d); ok {
+		value, ok, err := recall(d)
+		if err != nil {
+			return dep.KVExists(false), err
+		}
+		if ok {
 			return value.(dep.KVExists), nil
 		}
 
@@ -206,7 +230,11 @@ func v1KVExistsGetFunc(recall hcat.Recaller) interface{} {
 			return result, err
 		}
 
-		if value, ok := recall(d); ok {
+		value, ok, err := recall(d)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
 			return value.(*dep.KeyPair), nil
 		}
 

--- a/tfunc/tfunc_test.go
+++ b/tfunc/tfunc_test.go
@@ -63,7 +63,8 @@ type fakeWatcher struct {
 func (fakeWatcher) Buffering(hcat.Notifier) bool  { return false }
 func (f fakeWatcher) Complete(hcat.Notifier) bool { return true }
 func (f fakeWatcher) Recaller(hcat.Notifier) hcat.Recaller {
-	return func(d dep.Dependency) (value interface{}, found bool) {
-		return f.Store.Recall(d.ID())
+	return func(d dep.Dependency) (value interface{}, found bool, err error) {
+		v, found := f.Store.Recall(d.ID())
+		return v, found, nil
 	}
 }

--- a/tfunc/vault.go
+++ b/tfunc/vault.go
@@ -45,7 +45,11 @@ func secretFunc(recall hcat.Recaller) interface{} {
 			return nil, err
 		}
 
-		if value, ok := recall(d); ok {
+		value, ok, err := recall(d)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
 			return value.(*dep.Secret), nil
 		}
 
@@ -67,7 +71,11 @@ func secretsFunc(recall hcat.Recaller) interface{} {
 			return nil, err
 		}
 
-		if value, ok := recall(d); ok {
+		value, ok, err := recall(d)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
 			result = value.([]string)
 			return result, nil
 		}

--- a/watcher.go
+++ b/watcher.go
@@ -399,7 +399,7 @@ func (w *Watcher) Poll(deps ...dep.Dependency) {
 // Recaller returns a Recaller (function) that wraps the Store (cache)
 // to enable tracking dependencies on the Watcher.
 func (w *Watcher) Recaller(n Notifier) Recaller {
-	return func(dep dep.Dependency) (interface{}, bool) {
+	return func(dep dep.Dependency) (interface{}, bool, error) {
 		w.track(n, dep)
 		data, ok := w.cache.Recall(dep.ID())
 		switch {
@@ -408,7 +408,7 @@ func (w *Watcher) Recaller(n Notifier) Recaller {
 		default:
 			w.Poll(dep)
 		}
-		return data, ok
+		return data, ok, nil
 	}
 }
 

--- a/watcher.go
+++ b/watcher.go
@@ -336,6 +336,25 @@ func (w *Watcher) Deregister(ns ...Notifier) {
 	}
 }
 
+// ValidateTemplate verifies that executing the fetch requests of
+// a template's dependencies does not error.
+func (w *Watcher) ValidateTemplate(t *Template) error {
+	recaller := func(dep dep.Dependency) (interface{}, bool, error) {
+		data, _, err := dep.Fetch(w.clients)
+		if err != nil {
+			return nil, false, err
+		}
+		return data, true, nil
+	}
+	_, err := t.Execute(recaller)
+	t.Notify(nil)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // Track is used to add dependencies to be monitored by the watcher. It sets
 // everything up but stops short of running the polling, waiting for an
 // explicit start (see Poll below).

--- a/watcher_test.go
+++ b/watcher_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/hcat/dep"
 	idep "github.com/hashicorp/hcat/internal/dependency"
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestWatcherAdd(t *testing.T) {
@@ -1063,5 +1064,23 @@ func newWatcher() *Watcher {
 	return NewWatcher(WatcherInput{
 		Clients: NewClientSet(),
 		Cache:   NewStore(),
+	})
+}
+
+func TestWatcherValidateTemplate(t *testing.T) {
+	t.Run("happy-path", func(t *testing.T) {
+		w := newWatcher()
+		defer w.Stop()
+		tt := echoTemplate("foo")
+		err := w.ValidateTemplate(tt)
+		assert.NoError(t, err)
+	})
+
+	t.Run("fetch-errors", func(t *testing.T) {
+		w := newWatcher()
+		defer w.Stop()
+		tt := errorTemplate("foo")
+		err := w.ValidateTemplate(tt)
+		assert.Error(t, err)
 	})
 }


### PR DESCRIPTION
This is to fix an issue with the CTS create task API where the request hangs when a call to Consul fails. 

If, for example, a task created via the API specifies a datacenter that does not exist, the controller's main Run method [detects the error through the watcher's error channel and logs this error](https://github.com/hashicorp/consul-terraform-sync/blob/3ec43eb16adc162a2b7ac230365478d69cf18fde/controller/readwrite.go#L89-L97). However, the [createTask method](https://github.com/hashicorp/consul-terraform-sync/blob/main/controller/readwrite.go#L385-L400) used by the API does not know that this error has occurred and gets stuck in a loop waiting on the RenderTemplate to complete, which it never will complete.

My solution for this is to have a synchronous validation method that can call the Fetch for all dependencies and return any errors. This method would be called after the template has been registered, and if there is an error, we'd deregister the template and return the error.

This currently is still a work in progress because it's only working if the check for whether the template `isDirty()` is removed, which I haven't determined the reasoning for.