### PR TITLE
change Clients to a public field on watcher

### DIFF
--- a/resolver.go
+++ b/resolver.go
@@ -31,6 +31,7 @@ type Watcherer interface {
 	Buffering(Notifier) bool
 	Recaller(Notifier) Recaller
 	Complete(Notifier) bool
+	Clients() Looker
 }
 
 // Templater the interface the Template provides.

--- a/tfunc/tfunc_test.go
+++ b/tfunc/tfunc_test.go
@@ -62,6 +62,7 @@ type fakeWatcher struct {
 
 func (fakeWatcher) Buffering(hcat.Notifier) bool  { return false }
 func (f fakeWatcher) Complete(hcat.Notifier) bool { return true }
+func (f fakeWatcher) Clients() hcat.Looker        { return nil }
 func (f fakeWatcher) Recaller(hcat.Notifier) hcat.Recaller {
 	return func(d dep.Dependency) (value interface{}, found bool) {
 		return f.Store.Recall(d.ID())

--- a/watcher.go
+++ b/watcher.go
@@ -176,6 +176,12 @@ func (w *Watcher) WatchVaultToken(token string) error {
 	return nil
 }
 
+// Clients returns the Looker/ClientSet to give easy access to the clients
+// after initial setup.
+func (w *Watcher) Clients() Looker {
+	return w.clients
+}
+
 // WaitCh returns an error channel and runs Wait sending the result down
 // the channel. Useful for when you need to use Wait in a select block.
 func (w *Watcher) WaitCh(ctx context.Context) <-chan error {

--- a/watcher_test.go
+++ b/watcher_test.go
@@ -12,6 +12,19 @@ import (
 	"github.com/pkg/errors"
 )
 
+func TestWatcherClients(t *testing.T) {
+	w := newWatcher()
+	defer w.Stop()
+	var _ Watcherer = Watcherer(newWatcher())
+
+	clients := w.Clients()
+	switch clients.(type) {
+	case *ClientSet:
+	default:
+		t.Errorf("w.Clients() returning wrong type")
+	}
+}
+
 func TestWatcherAdd(t *testing.T) {
 	t.Run("updates-tracker", func(t *testing.T) {
 		w := newWatcher()


### PR DESCRIPTION
Not really internal and handy to have access to for other things.

Specifically it makes it easier to implement a custom Recaller for
testing template validity in CTS (example of this to be added to
doc_test.go).