### PR TITLE
make template.Notify()'s bool return meaningful

### DIFF
--- a/template.go
+++ b/template.go
@@ -141,13 +141,14 @@ func (t *Template) ID() string {
 
 // Notify template that a dependency it relies on has been updated. Works by
 // marking the template so it knows it has new data to process when Execute is
-// called.
+// called. Return true to indicate that the template needs to be re-run.
 func (t *Template) Notify(interface{}) bool {
 	select {
 	case t.dirty <- struct{}{}:
+		return true
 	default:
+		return false
 	}
-	return true
 }
 
 // Check and clear dirty flag


### PR DESCRIPTION
Change template.Notify() to return true if it marks the template as
dirty, returns false if it has already been marked as dirty.

This change is to clarify the meaning of the template's Notify's boolean
return value as well as making it play nicer with the watcher to help
eliminate duplicate template notifications.