### PR TITLE
Add locks to a couple watcher methods

### DIFF
--- a/watcher.go
+++ b/watcher.go
@@ -682,6 +682,8 @@ func (t *tracker) stopViews() {
 func (t *tracker) notifiersFor(view IDer) []Notifier {
 	viewID := view.ID()
 	results := make([]Notifier, 0, 8)
+	t.Lock()
+	defer t.Unlock()
 	for _, tp := range t.tracked {
 		if tp.view == viewID {
 			results = append(results, t.notifiers[tp.notify])
@@ -693,6 +695,8 @@ func (t *tracker) notifiersFor(view IDer) []Notifier {
 // complete returns true if every dependency used has been initialized
 // ie. it returns true if all values have been fetched
 func (t *tracker) complete(notifier IDer) bool {
+	t.Lock()
+	defer t.Unlock()
 	for _, tp := range t.tracked {
 		thisNotifier := tp.notify == notifier.ID()
 		cacheNotAccessed := !tp.cacheAccessed


### PR DESCRIPTION
In CTS the notifiersFor() was causing a race condition detected by the go race
detector which points to the usage of `w.tracker` in notifersFor():

```
WARNING: DATA RACE
Read at 0x00c000268488 by goroutine 46:
  github.com/hashicorp/hcat.(*tracker).notifiersFor()
      /Users/lornasong/go/src/github.com/hashicorp/consul-terraform-sync/vendor/github.com/hashicorp/hcat/watcher.go:685 +0x9c
	  ...
Previous write at 0x00c000268488 by goroutine 45:
  github.com/hashicorp/hcat.(*tracker).sweep()
      /Users/lornasong/go/src/github.com/hashicorp/consul-terraform-sync/vendor/github.com/hashicorp/hcat/watcher.go:736 +0x1e4
```

Also pre-emptively added locks to complete() since it also accesses `w.tracker`.