### PR TITLE
fix stable sorting (no more <=)

### DIFF
--- a/internal/dependency/catalog_node.go
+++ b/internal/dependency/catalog_node.go
@@ -99,7 +99,13 @@ func (d *CatalogNodeQuery) Fetch(clients dep.Clients) (interface{}, *dep.Respons
 			EnableTagOverride: v.EnableTagOverride,
 		})
 	}
-	sort.Stable(ByService(services))
+	sort.SliceStable(services,
+		func(i, j int) bool {
+			if services[i].Service == services[j].Service {
+				return services[i].ID < services[j].ID
+			}
+			return services[i].Service < services[j].Service
+		})
 
 	detail := &dep.CatalogNode{
 		Node: &dep.Node{
@@ -142,18 +148,6 @@ func (d *CatalogNodeQuery) String() string {
 // Stop halts the dependency's fetch function.
 func (d *CatalogNodeQuery) Stop() {
 	close(d.stopCh)
-}
-
-// ByService is a sorter of node services by their service name and then ID.
-type ByService []*dep.CatalogNodeService
-
-func (s ByService) Len() int      { return len(s) }
-func (s ByService) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
-func (s ByService) Less(i, j int) bool {
-	if s[i].Service == s[j].Service {
-		return s[i].ID <= s[j].ID
-	}
-	return s[i].Service <= s[j].Service
 }
 
 func (d *CatalogNodeQuery) SetOptions(opts QueryOptions) {

--- a/internal/dependency/catalog_nodes.go
+++ b/internal/dependency/catalog_nodes.go
@@ -80,7 +80,13 @@ func (d *CatalogNodesQuery) Fetch(clients dep.Clients) (interface{}, *dep.Respon
 
 	// Sort unless the user explicitly asked for nearness
 	if d.near == "" {
-		sort.Stable(ByNode(nodes))
+		sort.SliceStable(nodes,
+			func(i, j int) bool {
+				if nodes[i].Node == nodes[j].Node {
+					return nodes[i].Address < nodes[j].Address
+				}
+				return nodes[i].Node < nodes[j].Node
+			})
 	}
 
 	rm := &dep.ResponseMetadata{
@@ -120,18 +126,6 @@ func (d *CatalogNodesQuery) String() string {
 // Stop halts the dependency's fetch function.
 func (d *CatalogNodesQuery) Stop() {
 	close(d.stopCh)
-}
-
-// ByNode is a sortable list of nodes by name and then IP address.
-type ByNode []*dep.Node
-
-func (s ByNode) Len() int      { return len(s) }
-func (s ByNode) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
-func (s ByNode) Less(i, j int) bool {
-	if s[i].Node == s[j].Node {
-		return s[i].Address <= s[j].Address
-	}
-	return s[i].Node <= s[j].Node
 }
 
 func (d *CatalogNodesQuery) SetOptions(opts QueryOptions) {

--- a/internal/dependency/catalog_services.go
+++ b/internal/dependency/catalog_services.go
@@ -121,7 +121,13 @@ func (d *CatalogServicesQuery) Fetch(clients dep.Clients) (interface{}, *dep.Res
 		})
 	}
 
-	sort.Stable(ByName(catalogServices))
+	sort.SliceStable(catalogServices,
+		func(i, j int) bool {
+			if catalogServices[i].Name < catalogServices[j].Name {
+				return true
+			}
+			return false
+		})
 
 	rm := &dep.ResponseMetadata{
 		LastIndex:   qm.LastIndex,
@@ -167,18 +173,6 @@ func (d *CatalogServicesQuery) Stop() {
 
 func (d *CatalogServicesQuery) SetOptions(opts QueryOptions) {
 	d.opts = opts
-}
-
-// ByName is a sortable slice of CatalogService structs.
-type ByName []*dep.CatalogSnippet
-
-func (s ByName) Len() int      { return len(s) }
-func (s ByName) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
-func (s ByName) Less(i, j int) bool {
-	if s[i].Name <= s[j].Name {
-		return true
-	}
-	return false
 }
 
 // stringsSplit2 splits a string

--- a/internal/dependency/health_service.go
+++ b/internal/dependency/health_service.go
@@ -255,7 +255,15 @@ func (d *HealthServiceQuery) Fetch(clients dep.Clients) (interface{}, *dep.Respo
 
 	// Sort unless the user explicitly asked for nearness
 	if d.near == "" {
-		sort.Stable(ByNodeThenID(list))
+		sort.SliceStable(list,
+			func(i, j int) bool {
+				if list[i].Node < list[j].Node {
+					return true
+				} else if list[i].Node == list[j].Node {
+					return list[i].ID < list[j].ID
+				}
+				return false
+			})
 	}
 
 	rm := &dep.ResponseMetadata{
@@ -324,21 +332,6 @@ func acceptStatus(filters []string, status string) bool {
 		if filter == status || filter == HealthAny {
 			return true
 		}
-	}
-	return false
-}
-
-// ByNodeThenID is a sortable slice of Service
-type ByNodeThenID []*dep.HealthService
-
-// Len, Swap, and Less are used to implement the sort.Sort interface.
-func (s ByNodeThenID) Len() int      { return len(s) }
-func (s ByNodeThenID) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
-func (s ByNodeThenID) Less(i, j int) bool {
-	if s[i].Node < s[j].Node {
-		return true
-	} else if s[i].Node == s[j].Node {
-		return s[i].ID <= s[j].ID
 	}
 	return false
 }


### PR DESCRIPTION
The code previously used sort.Stable with the sorting interface. It
mistakenly used <= in the Less comparisons where it should have been
just <. This would 'break' stable sort in that it wouldn't be stable
(ie. sort order could change between calls) with 2 equal values.

This replaces the <= with < while also converting the code to use the
newer, and more appropriate, sort.StableSlice()... which uses a function
instead of the interface.