### PR TITLE
refactor buffer period tests to eliminate races

### DIFF
--- a/buffer_period.go
+++ b/buffer_period.go
@@ -9,25 +9,35 @@ import (
 // timers is a threadsafe object to manage multiple timers that represent
 // buffer periods for objects by their ID.
 type timers struct {
+	mux sync.RWMutex
 	// timers is the map of IDs to their active buffer timers.
 	timers   map[string]*timer
 	buffered map[string]bool
 	ch       chan string
-	mux      sync.RWMutex
 }
 
 // timer is an internal representation of a single buffer state.
 type timer struct {
-	id       string
+	mux sync.RWMutex
+
+	id string
+	ch chan string
+
+	deadline time.Time
 	min      time.Duration
 	max      time.Duration
-	ch       chan string
-	timer    *time.Timer
-	deadline time.Time
 
+	timer      timerer
+	newTimerer func(d time.Duration) timerer
 	cancelTick context.CancelFunc
 	isActive   bool
-	mux        sync.RWMutex
+}
+
+// time.Timer interface to allow mocking for testing without races
+type timerer interface {
+	Reset(time.Duration) bool
+	GetC() <-chan time.Time
+	Stop() bool
 }
 
 func newTimers() *timers {
@@ -95,12 +105,17 @@ func (t *timers) isBuffering(id string) bool {
 // tick activates the buffer period and updates the timer.
 // Returns false if no timer is found.
 func (t *timers) tick(id string) bool {
+	return t._tick(id, time.Now())
+}
+
+// tick with 'now' passed in to allow testing
+func (t *timers) _tick(id string, now time.Time) bool {
 	t.mux.Lock()
 	defer t.mux.Unlock()
 
 	timer, ok := t.timers[id]
 	if ok {
-		timer.tick()
+		timer.tick(now)
 	}
 	return ok
 }
@@ -116,6 +131,27 @@ func (t *timers) Reset(id string) {
 	}
 }
 
+// add timer using test version of time.Timer
+func (t *timers) testAdd(min, max time.Duration, id string) bool {
+	ok := t.Add(min, max, id)
+	if ok {
+		t.timers[id].newTimerer = NewTestTimer
+	}
+	return ok
+}
+
+// returns the timer for id
+func (t *timers) get(id string) *timer {
+	t.mux.Lock()
+	defer t.mux.Unlock()
+
+	if timer, ok := t.timers[id]; ok {
+		return timer
+	}
+	return nil
+}
+
+// //////////////////////////////////////////////////////////////////////
 // newTimer creates a new buffer timer for the given template.
 func newTimer(ch chan string, min, max time.Duration, id string) *timer {
 	return &timer{
@@ -123,6 +159,8 @@ func newTimer(ch chan string, min, max time.Duration, id string) *timer {
 		min: min,
 		max: max,
 		ch:  ch,
+		// change to use test timer in tests
+		newTimerer: NewRealTimer,
 	}
 }
 
@@ -133,9 +171,7 @@ func (t *timer) stop() {
 }
 
 // tick updates the minimum buffer timer
-func (t *timer) tick() {
-	now := time.Now()
-
+func (t *timer) tick(now time.Time) {
 	if t.active() {
 		t.activeTick(now)
 		return
@@ -154,7 +190,7 @@ func (t *timer) active() bool {
 // calculate the max deadline.
 func (t *timer) inactiveTick(now time.Time) {
 	if t.timer == nil {
-		t.timer = time.NewTimer(t.min)
+		t.timer = t.newTimerer(t.min)
 	} else {
 		t.timer.Reset(t.min)
 	}
@@ -170,7 +206,7 @@ func (t *timer) inactiveTick(now time.Time) {
 		select {
 		case <-ctx.Done():
 			return
-		case <-t.timer.C:
+		case <-t.timer.GetC():
 			t.mux.Lock()
 			t.ch <- t.id
 			t.isActive = false
@@ -208,4 +244,50 @@ func (t *timer) reset() {
 
 	t.cancelTick()
 	t.isActive = false
+}
+
+// //////////////////////////////////////////////////////////////////////
+// time.Timer wrapper and a mocked/test Timer implementation
+// They both meet the `timerer` interface above
+
+// time.Timer wrapped to fit the interface (needed a getter for the channel)
+type realTimer struct {
+	time.Timer
+}
+
+func NewRealTimer(d time.Duration) timerer {
+	return &realTimer{*time.NewTimer(d)}
+}
+
+func (tt *realTimer) GetC() <-chan time.Time {
+	return tt.C
+}
+
+// time.Timer for testing where it totals up the timer time for comparison
+type testTimer struct {
+	C         chan time.Time
+	totalTime time.Duration
+}
+
+// testTimer
+func NewTestTimer(d time.Duration) timerer {
+	C := make(chan time.Time)
+	return &testTimer{C: C, totalTime: d}
+}
+
+func (tt *testTimer) GetC() <-chan time.Time {
+	return tt.C
+}
+
+func (tt *testTimer) Reset(d time.Duration) bool {
+	tt.totalTime += d
+	return true
+}
+
+func (tt *testTimer) Stop() bool {
+	return true
+}
+
+func (tt *testTimer) send() {
+	tt.C <- time.Now()
 }

--- a/buffer_period_test.go
+++ b/buffer_period_test.go
@@ -7,79 +7,98 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func getTestTimer(ts *timers, name string) *testTimer {
+	timer, ok := ts.get(name).timer.(*testTimer)
+	if ok {
+		return timer
+	}
+	panic("should be *testTimer")
+}
+
 func TestBufferPeriod(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
-		name           string
-		min            time.Duration
-		max            time.Duration
-		snoozeCount    int64
-		snoozeAfter    time.Duration
-		expectedWithin time.Duration
+		name        string
+		min         time.Duration
+		max         time.Duration
+		snoozeCount int64
+		expected    time.Duration // usually min + (snoozeCount * min)
 	}{
 		{
-			name: "one period",
-			min:  time.Duration(2 * time.Millisecond),
-			max:  time.Duration(10 * time.Millisecond),
+			name:     "no buffering",
+			min:      time.Duration(2 * time.Millisecond),
+			max:      time.Duration(10 * time.Millisecond),
+			expected: time.Duration(2 * time.Millisecond),
 		},
 		{
-			name:        "snooze once",
+			name:        "snooze one",
 			min:         time.Duration(4 * time.Millisecond),
 			max:         time.Duration(12 * time.Millisecond),
 			snoozeCount: 1,
-			snoozeAfter: time.Duration(1 * time.Millisecond),
+			expected:    time.Duration(8 * time.Millisecond),
+		},
+		{
+			name:        "snooze many",
+			min:         time.Duration(4 * time.Millisecond),
+			max:         time.Duration(21 * time.Millisecond),
+			snoozeCount: 3,
+			expected:    time.Duration(16 * time.Millisecond),
 		},
 		{
 			name:        "deadline",
 			min:         time.Duration(4 * time.Millisecond),
 			max:         time.Duration(6 * time.Millisecond),
 			snoozeCount: 3,
-			snoozeAfter: time.Duration(1 * time.Millisecond),
+			expected:    time.Duration(6 * time.Millisecond),
+			// this is 6 as activeTick() is a noop if past the deadline
 		},
 	}
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			tc := testCase
-			t.Parallel()
 
 			triggerCh := make(chan string)
 			bufferPeriods := newTimers()
 			go bufferPeriods.Run(triggerCh)
 			defer bufferPeriods.Stop()
 
-			bufferPeriods.Add(tc.min, tc.max, tc.name)
+			bufferPeriods.testAdd(tc.min, tc.max, tc.name)
 			assert.False(t, bufferPeriods.Buffered(tc.name),
 				"buffer isn't activated yet to be buffered")
 
-			bufferPeriods.tick(tc.name)
+			// manually run tick, 1 + snoozeCount
+			// use static 'now' for testing
+			now := time.Now()
+			bufferPeriods._tick(tc.name, now)
+			now = now.Add(tc.min) // fake time passes..
 
-			// Simulate consecutive calls to resolver.Run(template)
-			go func() {
-				for i := int64(0); i < tc.snoozeCount; i++ {
-					<-time.After(tc.snoozeAfter)
-					bufferPeriods.tick(tc.name)
-				}
-			}()
-
-			// Test signal is received within expected duration
-			expectedWithin := tc.min + time.Duration(tc.snoozeCount)*tc.snoozeAfter
-			expectedWithin += 3 * time.Millisecond // add a bit of leniency
-			select {
-			case id := <-triggerCh:
-				assert.Equal(t, tc.name, id, "unexpected id")
-			case <-time.After(expectedWithin):
-				assert.Fail(t, "buffer did not complete within expected period", expectedWithin)
+			for i := int64(0); i < tc.snoozeCount; i++ {
+				bufferPeriods._tick(tc.name, now)
+				now = now.Add(tc.min) // fake time passes..
 			}
 
+			// pull out the test timer for examination
+			timer := getTestTimer(bufferPeriods, tc.name)
+
+			// testTimer adds up ticks (time.Reset) into totalTime
+			if timer.totalTime != tc.expected {
+				t.Errorf("buffer time (%s) doesn't match expected (%s)",
+					timer.totalTime, tc.expected)
+			}
+
+			timer.send()      // fake a time.Timer expiring
+			id := <-triggerCh // previous send() should enable this
+			if id != tc.name {
+				t.Errorf("id (%s) should match name (%s)", id, tc.name)
+			}
+			// Test signal is received within expected duration
 			assert.True(t, bufferPeriods.Buffered(tc.name), "id should be cached as buffered")
 		})
 	}
 
 	t.Run("not configured", func(t *testing.T) {
-		t.Parallel()
-
 		triggerCh := make(chan string)
 		bufferPeriods := newTimers()
 		go bufferPeriods.Run(triggerCh)
@@ -97,8 +116,6 @@ func TestBufferPeriod(t *testing.T) {
 	})
 
 	t.Run("multiple", func(t *testing.T) {
-		t.Parallel()
-
 		triggerCh := make(chan string, 5)
 		bufferPeriods := newTimers()
 		go bufferPeriods.Run(triggerCh)
@@ -106,11 +123,23 @@ func TestBufferPeriod(t *testing.T) {
 
 		first := time.Duration(3 * time.Millisecond)
 		second := time.Duration(6 * time.Millisecond)
-		bufferPeriods.Add(first, first*3, "first")
-		bufferPeriods.Add(second, second*3, "second")
+		bufferPeriods.testAdd(first, first*3, "first")
+		bufferPeriods.testAdd(second, second*3, "second")
 
 		bufferPeriods.tick("first")
 		bufferPeriods.tick("second")
+
+		if tmr := getTestTimer(bufferPeriods, "first"); tmr.totalTime != first {
+			t.Error("first tick times don't match")
+		} else { // times match, so send a time down the Timer channel
+			tmr.send()
+		}
+
+		if tmr := getTestTimer(bufferPeriods, "second"); tmr.totalTime != second {
+			t.Error("second tick times don't match")
+		} else { // times match, so send a time down the Timer channel
+			tmr.send()
+		}
 
 		completed := make(chan struct{})
 		go func() {
@@ -118,6 +147,11 @@ func TestBufferPeriod(t *testing.T) {
 			assert.Equal(t, "second", <-triggerCh)
 			completed <- struct{}{}
 		}()
+
+		_, ok := bufferPeriods.get("first").timer.(*testTimer)
+		if !ok {
+			t.Error("not using fake timer")
+		}
 
 		select {
 		case <-time.After(8800 * time.Microsecond):
@@ -127,36 +161,31 @@ func TestBufferPeriod(t *testing.T) {
 	})
 
 	t.Run("stop unused timers", func(t *testing.T) {
-		t.Parallel()
-
 		triggerCh := make(chan string, 5)
 		bufferPeriods := newTimers()
 		go bufferPeriods.Run(triggerCh)
 
-		bufferPeriods.Add(time.Millisecond, 2*time.Millisecond, "unused")
+		bufferPeriods.testAdd(time.Millisecond, 2*time.Millisecond, "unused")
+		if _, ok := bufferPeriods.timers["unused"]; !ok {
+			t.Error("timers entry should exist")
+		}
 		bufferPeriods.Stop()
+		if _, ok := bufferPeriods.timers["unused"]; ok {
+			t.Error("timers entry should *not* exist")
+		}
 	})
 
 	t.Run("reset", func(t *testing.T) {
-		t.Parallel()
-
 		triggerCh := make(chan string, 5)
 		bufferPeriods := newTimers()
 		go bufferPeriods.Run(triggerCh)
 		defer bufferPeriods.Stop()
 
 		id := "foo"
-		bufferPeriods.Add(2*time.Millisecond, 8*time.Millisecond, id)
+		bufferPeriods.testAdd(2*time.Millisecond, 8*time.Millisecond, id)
 		bufferPeriods.tick(id) // activate buffer
 		assert.True(t, bufferPeriods.timers[id].active())
-
 		bufferPeriods.Reset(id)
-
-		select {
-		case <-triggerCh:
-			t.Fatalf("buffer was reset and should not have triggered")
-		case <-time.After(2 * time.Millisecond):
-			assert.False(t, bufferPeriods.timers[id].active())
-		}
+		assert.False(t, bufferPeriods.timers[id].active())
 	})
 }


### PR DESCRIPTION
Refactored the code and tests to allow for comparing durations instead of using wall time. Eliminates need for timing tests which are inherently racy (and fail a lot during CI due to slower test instances).