### PR TITLE
simplify checkLeaseWait testing

### DIFF
--- a/internal/dependency/vault_read.go
+++ b/internal/dependency/vault_read.go
@@ -11,10 +11,8 @@ import (
 	"github.com/pkg/errors"
 )
 
-var (
-	// Ensure implements
-	_ isDependency = (*VaultReadQuery)(nil)
-)
+// Ensure implements
+var _ isDependency = (*VaultReadQuery)(nil)
 
 // VaultReadQuery is the dependency to Vault for a secret
 type VaultReadQuery struct {
@@ -82,7 +80,7 @@ func (d *VaultReadQuery) Fetch(clients dep.Clients) (interface{}, *dep.ResponseM
 	}
 
 	if !vaultSecretRenewable(d.secret) {
-		dur := leaseCheckWait(d.secret)
+		dur := leaseCheckWait(d.secret, nil)
 		d.sleepCh <- dur
 	}
 
@@ -150,7 +148,6 @@ func (d *VaultReadQuery) readSecret(clients dep.Clients, opts *QueryOptions) (*a
 
 	vaultSecret, err := vaultClient.Logical().ReadWithData(d.secretPath,
 		d.queryValues)
-
 	if err != nil {
 		return nil, errors.Wrap(err, d.ID())
 	}

--- a/internal/dependency/vault_write.go
+++ b/internal/dependency/vault_write.go
@@ -13,10 +13,8 @@ import (
 	"github.com/pkg/errors"
 )
 
-var (
-	// Ensure implements
-	_ isDependency = (*VaultWriteQuery)(nil)
-)
+// Ensure implements
+var _ isDependency = (*VaultWriteQuery)(nil)
 
 // VaultWriteQuery is the dependency to Vault for a secret
 type VaultWriteQuery struct {
@@ -89,7 +87,7 @@ func (d *VaultWriteQuery) Fetch(clients dep.Clients) (interface{}, *dep.Response
 	d.secret = transformSecret(vaultSecret, opts.DefaultLease)
 
 	if !vaultSecretRenewable(d.secret) {
-		dur := leaseCheckWait(d.secret)
+		dur := leaseCheckWait(d.secret, nil)
 		d.sleepCh <- dur
 	}
 


### PR DESCRIPTION
added test options to eliminate random jitter being used with tests (eliminates need for testing a range of values)

pass in the time.Now function so we can use a faked one for tests (eliminates a timing race)