### PR TITLE
initial commit of vault token monitoring watcher

### DIFF
--- a/vaulttoken/main_test.go
+++ b/vaulttoken/main_test.go
@@ -1,0 +1,199 @@
+package vaulttoken
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/hcat"
+	"github.com/hashicorp/vault/api"
+)
+
+const (
+	vaultAddr  = "http://127.0.0.1:8222"
+	vaultToken = "a_token"
+)
+
+var (
+	testVault   *vaultServer
+	testClients *hcat.ClientSet
+	tokenRoleId string
+)
+
+func TestMain(m *testing.M) {
+	os.Exit(main(m))
+}
+
+// sub-main so I can use defer
+func main(m *testing.M) int {
+	log.SetOutput(ioutil.Discard)
+	testVault = newTestVault()
+	defer func() { testVault.Stop() }()
+
+	clients := hcat.NewClientSet()
+	if err := clients.AddVault(hcat.VaultInput{
+		Address: vaultAddr,
+		Token:   vaultToken,
+	}); err != nil {
+		panic(err)
+	}
+
+	testClients = clients
+	tokenRoleId = vaultTokenSetup(clients)
+
+	return m.Run()
+}
+
+type vaultServer struct {
+	cmd *exec.Cmd
+}
+
+func (v vaultServer) Stop() error {
+	if v.cmd != nil && v.cmd.Process != nil {
+		return v.cmd.Process.Signal(os.Interrupt)
+	}
+	return nil
+}
+
+func newTestVault() *vaultServer {
+	path, err := exec.LookPath("vault")
+	if err != nil || path == "" {
+		panic("vault not found on $PATH")
+	}
+	args := []string{
+		"server", "-dev", "-dev-root-token-id", vaultToken,
+		"-dev-no-store-token",
+		"-dev-listen-address", strings.TrimPrefix(vaultAddr, "http://"),
+	}
+	cmd := exec.Command("vault", args...)
+	cmd.Stdout = ioutil.Discard
+	cmd.Stderr = ioutil.Discard
+
+	if err := cmd.Start(); err != nil {
+		panic("vault failed to start: " + err.Error())
+	}
+	return &vaultServer{
+		cmd: cmd,
+	}
+}
+
+// Sets up approle auto-auth for token generation/testing
+func vaultTokenSetup(clients *hcat.ClientSet) string {
+	vc := clients.Vault()
+
+	// vault auth enable approle
+	err := vc.Sys().EnableAuthWithOptions("approle",
+		&api.MountInput{
+			Type: "approle",
+		})
+	if err != nil && !strings.Contains(err.Error(), "path is already in use") {
+		panic(err)
+	}
+
+	// vault policy write foo 'path ...'
+	err = vc.Sys().PutPolicy("foo",
+		`path "secret/data/foo" { capabilities = ["read"] }`)
+	if err != nil {
+		panic(err)
+	}
+
+	// vault write auth/approle/role/foo ...
+	_, err = vc.Logical().Write("auth/approle/role/foo",
+		map[string]interface{}{
+			"token_policies":     "foo",
+			"secret_id_num_uses": 100,
+			"secret_id_ttl":      "5m",
+			"token_num_users":    10,
+			"token_ttl":          "7m",
+			"token_max_ttl":      "10m",
+		})
+	if err != nil {
+		panic(err)
+	}
+
+	var sec *api.Secret
+	// vault read -field=role_id auth/approle/role/foo/role-id
+	sec, err = vc.Logical().Read("auth/approle/role/foo/role-id")
+	if err != nil {
+		panic(err)
+	}
+	role_id := sec.Data["role_id"]
+	return role_id.(string)
+}
+
+// returns path to token file (which is created by the agent run)
+// token file isn't cleaned, so use returned path to remove it when done
+func runVaultAgent(clients *hcat.ClientSet, role_id string) string {
+	dir, err := os.MkdirTemp("", "consul-template-test")
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(dir)
+
+	tokenFile := filepath.Join("", "vatoken.txt")
+
+	role_idPath := filepath.Join(dir, "roleid")
+	secret_idPath := filepath.Join(dir, "secretid")
+	vaconf := filepath.Join(dir, "vault-agent-config.json")
+
+	// Generate secret_id, need new one for each agent run
+	// vault write -f -field secret_id auth/approle/role/foo/secret-id
+	vc := clients.Vault()
+	sec, err := vc.Logical().Write("auth/approle/role/foo/secret-id", nil)
+	if err != nil {
+		panic(err)
+	}
+	secret_id := sec.Data["secret_id"].(string)
+	err = os.WriteFile(secret_idPath, []byte(secret_id), 0o444)
+	if err != nil {
+		panic(err)
+	}
+	err = os.WriteFile(role_idPath, []byte(role_id), 0o444)
+	if err != nil {
+		panic(err)
+	}
+
+	type obj map[string]interface{}
+	type list []obj
+	va := obj{
+		"vault": obj{"address": vaultAddr},
+		"auto_auth": obj{
+			"method": obj{
+				"type": "approle",
+				"config": obj{
+					"role_id_file_path":   role_idPath,
+					"secret_id_file_path": secret_idPath,
+				},
+				"wrap_ttl": "5m",
+			},
+			"sinks": list{
+				{"sink": obj{"type": "file", "config": obj{"path": tokenFile}}},
+			},
+		},
+	}
+	txt, err := json.Marshal(va)
+	if err != nil {
+		panic(err)
+	}
+	err = os.WriteFile(vaconf, txt, 0o644)
+	if err != nil {
+		panic(err)
+	}
+
+	args := []string{
+		"agent", "-exit-after-auth", "-config=" + vaconf,
+	}
+	cmd := exec.Command("vault", args...)
+	cmd.Stdout = ioutil.Discard
+	cmd.Stderr = ioutil.Discard
+
+	if err := cmd.Run(); err != nil {
+		panic("vault agent failed to run: " + err.Error())
+	}
+	return tokenFile
+}

--- a/vaulttoken/notifier.go
+++ b/vaulttoken/notifier.go
@@ -1,0 +1,28 @@
+package vaulttoken
+
+import (
+	"github.com/hashicorp/hcat/dep"
+)
+
+type callback func(any) bool
+
+// dep Notifier for use by vault token above and in tests
+type callbackNotifier struct {
+	dep dep.Dependency
+	fun callback
+}
+
+// returned boolean controls watcher.Watch channel output
+// ie. returning false will skip sending it on that channel.
+func (n callbackNotifier) Notify(d any) (ok bool) {
+	if n.fun != nil {
+		return n.fun(d)
+	} else {
+		return true
+	}
+}
+
+// unique ID for this notifier (amoung the pop of notifiers)
+func (n callbackNotifier) ID() string {
+	return n.dep.ID()
+}

--- a/vaulttoken/vault_agent_token.go
+++ b/vaulttoken/vault_agent_token.go
@@ -1,0 +1,116 @@
+package vaulttoken
+
+import (
+	"os"
+	"time"
+
+	"github.com/hashicorp/hcat/dep"
+	"github.com/pkg/errors"
+)
+
+// Ensure implements
+var _ dep.Dependency = (*VaultAgentTokenQuery)(nil)
+
+const (
+	// VaultAgentTokenSleepTime is the amount of time to sleep between queries, since
+	// the fsnotify library is not compatible with solaris and other OSes yet.
+	VaultAgentTokenSleepTime = 15 * time.Second
+)
+
+// VaultAgentTokenQuery is the dependency to Vault Agent token
+type VaultAgentTokenQuery struct {
+	stopCh chan struct{}
+	stat   os.FileInfo
+	path   string
+}
+
+// NewVaultAgentTokenQuery creates a new dependency.
+func NewVaultAgentTokenQuery(path string) (*VaultAgentTokenQuery, error) {
+	return &VaultAgentTokenQuery{
+		stopCh: make(chan struct{}, 1),
+		path:   path,
+	}, nil
+}
+
+// Fetch retrieves this dependency and returns the result or any errors that
+// occur in the process.
+func (d *VaultAgentTokenQuery) Fetch(clients dep.Clients) (interface{}, *dep.ResponseMetadata, error) {
+	var token string
+	select {
+	case <-d.stopCh:
+		return "", nil, dep.ErrStopped
+	case r := <-d.watch(d.stat):
+
+		if r.err != nil {
+			return "", nil, errors.Wrap(r.err, d.ID())
+		}
+
+		raw_token, err := os.ReadFile(d.path)
+		if err != nil {
+			return "", nil, errors.Wrap(err, d.ID())
+		}
+
+		d.stat = r.stat
+		token = string(raw_token)
+	}
+
+	return token, &dep.ResponseMetadata{
+		LastIndex: uint64(time.Now().Unix()),
+	}, nil
+}
+
+// ID returns the human-friendly version of this dependency.
+func (d *VaultAgentTokenQuery) ID() string {
+	return "vault-agent.token"
+}
+
+// Stop halts the dependency's fetch function.
+func (d *VaultAgentTokenQuery) Stop() {
+	close(d.stopCh)
+}
+
+// Stringer interface reuses ID
+func (d *VaultAgentTokenQuery) String() string {
+	return d.ID()
+}
+
+type watchResult struct {
+	stat os.FileInfo
+	err  error
+}
+
+// watch watches the file for changes
+func (d *VaultAgentTokenQuery) watch(lastStat os.FileInfo) <-chan *watchResult {
+	ch := make(chan *watchResult, 1)
+
+	go func(lastStat os.FileInfo) {
+		for {
+			stat, err := os.Stat(d.path)
+			if err != nil {
+				select {
+				case <-d.stopCh:
+					return
+				case ch <- &watchResult{err: err}:
+					return
+				}
+			}
+
+			changed := lastStat == nil ||
+				lastStat.Size() != stat.Size() ||
+				lastStat.ModTime() != stat.ModTime()
+
+			if changed {
+				select {
+				case <-d.stopCh:
+					return
+				case ch <- &watchResult{stat: stat}:
+					return
+				}
+			}
+
+			time.Sleep(VaultAgentTokenSleepTime)
+		}
+	}(lastStat)
+
+	return ch
+}

--- a/vaulttoken/vault_agent_token_test.go
+++ b/vaulttoken/vault_agent_token_test.go
@@ -1,0 +1,109 @@
+package vaulttoken
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/hcat"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVaultAgentTokenQuery_Fetch(t *testing.T) {
+	// Don't use t.Parallel() here as the SetToken() calls are global and break
+	// other tests if run in parallel
+
+	// reset token back to original
+	vc := testClients.Vault()
+	defer vc.SetToken(vc.Token())
+
+	// Set up the Vault token file.
+	tokenFile, err := ioutil.TempFile("", "token1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tokenFile.Name())
+	testWrite(tokenFile.Name(), []byte("token"))
+
+	d, err := NewVaultAgentTokenQuery(tokenFile.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	clientSet := testClients
+	token, _, err := d.Fetch(clientSet)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, "token", token)
+
+	// Update the contents.
+	testWrite(tokenFile.Name(), []byte("another_token"))
+	token, _, err = d.Fetch(clientSet)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, "another_token", token)
+}
+
+func TestVaultAgentTokenQuery_Fetch_missingFile(t *testing.T) {
+	t.Parallel()
+
+	// Use a non-existant token file path.
+	d, err := NewVaultAgentTokenQuery("/tmp/invalid-file")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	clientSet := hcat.NewClientSet()
+	clientSet.AddVault(hcat.VaultInput{
+		Token: "foo",
+	})
+	_, _, err = d.Fetch(clientSet)
+	if err == nil || !strings.Contains(err.Error(), "no such file") {
+		t.Fatal(err)
+	}
+
+	// Token should be unaffected.
+	assert.Equal(t, "foo", clientSet.Vault().Token())
+}
+
+func testWrite(path string, contents []byte) error {
+	if path == "" {
+		panic("missing path")
+	}
+
+	parent := filepath.Dir(path)
+	if _, err := os.Stat(parent); os.IsNotExist(err) {
+		if err := os.MkdirAll(parent, 0o755); err != nil {
+			return err
+		}
+	}
+
+	f, err := ioutil.TempFile(parent, "")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(f.Name())
+
+	if _, err := f.Write(contents); err != nil {
+		return err
+	}
+
+	for _, err := range []error{
+		f.Sync(),
+		f.Close(),
+		os.Chmod(f.Name(), 0o644),
+		os.Rename(f.Name(), path),
+	} {
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/vaulttoken/vault_token.go
+++ b/vaulttoken/vault_token.go
@@ -1,0 +1,93 @@
+package vaulttoken
+
+import (
+	"github.com/hashicorp/hcat/dep"
+	"github.com/hashicorp/vault/api"
+	"github.com/pkg/errors"
+)
+
+// Ensure implements
+var _ dep.Dependency = (*VaultTokenQuery)(nil)
+
+// VaultTokenQuery is the dependency to Vault for a secret
+type VaultTokenQuery struct {
+	stopCh chan struct{}
+	secret *api.Secret
+}
+
+// NewVaultTokenQuery creates a new dependency.
+func NewVaultTokenQuery(token string) (*VaultTokenQuery, error) {
+	secret := &api.Secret{
+		Auth: &api.SecretAuth{
+			ClientToken:   token,
+			Renewable:     true,
+			LeaseDuration: 1,
+		},
+	}
+	return &VaultTokenQuery{
+		stopCh: make(chan struct{}, 1),
+		secret: secret,
+	}, nil
+}
+
+// Fetch queries the Vault API
+func (d *VaultTokenQuery) Fetch(clients dep.Clients) (interface{}, *dep.ResponseMetadata, error) {
+	select {
+	case <-d.stopCh:
+		return nil, nil, dep.ErrStopped
+	default:
+	}
+
+	vaultSecretRenewable := d.secret.Renewable
+	if d.secret.Auth != nil {
+		vaultSecretRenewable = d.secret.Auth.Renewable
+	}
+
+	// ??? event/log if this runs and vaultSecretRenewable is false
+
+	if vaultSecretRenewable {
+		err := d.renewSecret(clients)
+		if err != nil {
+			return nil, nil, errors.Wrap(err, d.ID())
+		}
+	}
+
+	return nil, nil, dep.ErrLeaseExpired
+}
+
+func (d *VaultTokenQuery) renewSecret(clients dep.Clients) error {
+	renewer, err := clients.Vault().NewRenewer(&api.RenewerInput{
+		Secret: d.secret,
+	})
+	if err != nil {
+		return err
+	}
+	go renewer.Renew()
+	defer renewer.Stop()
+
+	for {
+		select {
+		case err := <-renewer.DoneCh():
+			return err
+		case renewal := <-renewer.RenewCh():
+			d.secret = renewal.Secret
+		case <-d.stopCh:
+			return dep.ErrStopped
+		}
+	}
+}
+
+// Stop halts the dependency's fetch function.
+func (d *VaultTokenQuery) Stop() {
+	close(d.stopCh)
+}
+
+// ID returns the human-friendly version of this dependency.
+func (d *VaultTokenQuery) ID() string {
+	return "vault.token"
+}
+
+// Stringer interface reuses ID
+func (d *VaultTokenQuery) String() string {
+	return d.ID()
+}

--- a/vaulttoken/vault_token_test.go
+++ b/vaulttoken/vault_token_test.go
@@ -1,0 +1,72 @@
+package vaulttoken
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/vault/api"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewVaultTokenQuery(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		exp  *VaultTokenQuery
+		err  bool
+	}{
+		{
+			"default",
+			&VaultTokenQuery{
+				secret: &api.Secret{
+					Auth: &api.SecretAuth{
+						ClientToken:   "my-token",
+						Renewable:     true,
+						LeaseDuration: 1,
+					},
+				},
+			},
+			false,
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
+			act, err := NewVaultTokenQuery("my-token")
+			if (err != nil) != tc.err {
+				t.Fatal(err)
+			}
+
+			if act != nil {
+				act.stopCh = nil
+			}
+
+			assert.Equal(t, tc.exp, act)
+		})
+	}
+}
+
+func TestVaultTokenQuery_String(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		exp  string
+	}{
+		{
+			"default",
+			"vault.token",
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
+			d, err := NewVaultTokenQuery("my-token")
+			if err != nil {
+				t.Fatal(err)
+			}
+			assert.Equal(t, tc.exp, d.ID())
+		})
+	}
+}

--- a/vaulttoken/watcher.go
+++ b/vaulttoken/watcher.go
@@ -1,0 +1,188 @@
+package vaulttoken
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/hashicorp/hcat"
+	"github.com/hashicorp/hcat/events"
+	"github.com/hashicorp/vault/api"
+)
+
+type VaultTokenConfig struct {
+	Clients      *hcat.ClientSet
+	Context      context.Context
+	RetryFunc    hcat.RetryFunc
+	EventHandler events.EventHandler
+
+	Token, AgentTokenFile string
+	Unwrap, Renew         bool
+}
+type vaultTokenWatcher struct {
+	hcat.Watcher
+	event events.EventHandler
+}
+
+// VaultTokenWatcher monitors the vault token for updates
+func VaultTokenWatcher(c VaultTokenConfig) (*vaultTokenWatcher, error) {
+	raw_token := strings.TrimSpace(c.Token)
+	if raw_token == "" {
+		return nil, nil
+	}
+
+	unwrap := c.Unwrap
+	vault := c.Clients.Vault()
+	// get/set token once when kicked off, async after that..
+	token, err := unpackToken(vault, raw_token, unwrap)
+	if err != nil {
+		return nil, fmt.Errorf("vaultwatcher: %w", err)
+	}
+	vault.SetToken(token)
+
+	var once sync.Once
+	var watcher *vaultTokenWatcher
+	two := 2
+	getWatcher := func() *vaultTokenWatcher {
+		once.Do(func() {
+			watcher = &vaultTokenWatcher{
+				Watcher: *hcat.NewWatcher(hcat.WatcherInput{
+					Clients:        c.Clients,
+					VaultRetryFunc: c.RetryFunc,
+					EventHandler:   c.EventHandler,
+					DataBufferSize: &two,
+				}), event: c.EventHandler,
+			}
+		})
+		return watcher
+	}
+
+	// Vault Agent Token File process //
+	tokenFile := strings.TrimSpace(c.AgentTokenFile)
+	if tokenFile != "" {
+		w := getWatcher()
+		watchLoop, err := watchTokenFile(w, c)
+		if err != nil {
+			return nil, fmt.Errorf("vaultwatcher: %w", err)
+		}
+		go watchLoop()
+	}
+
+	// Vault Token Renewal process //
+	renewVault := vault.Token() != "" && c.Renew
+	if renewVault {
+		w := getWatcher()
+		vt, err := NewVaultTokenQuery(token)
+		n := callbackNotifier{dep: vt}
+		if err != nil {
+			w.Stop() // need to stop token file loop. use context.
+			return nil, fmt.Errorf("vaultwatcher: %w", err)
+		}
+		w.Track(n, vt)
+	}
+
+	return watcher, nil
+}
+
+// split out channel into module level variable to enable testing.
+// not 100% this as a good way to do this but it works for now.
+// small buffer to facilitate testing
+var tokenUpdate = make(chan string, 1)
+
+// kicks off using the watcher to monitor the agent token file for updates
+// handles updating the client with new tokens as they are written to the file
+func watchTokenFile(w *vaultTokenWatcher, c VaultTokenConfig) (func(), error) {
+	atf, err := NewVaultAgentTokenQuery(c.AgentTokenFile)
+
+	pipeit := func(d any) bool {
+		s, ok := d.(string)
+		if ok {
+			tokenUpdate <- s
+		}
+		return ok
+	}
+
+	n := callbackNotifier{dep: atf, fun: pipeit}
+	if err != nil {
+		return nil, fmt.Errorf("vaultwatcher: %w", err)
+	}
+	w.Track(n, atf)
+	w.Poll(atf)
+
+	vault := c.Clients.Vault()
+	raw_token := c.Token
+	return func() {
+		for {
+			select {
+			case err := <-w.WaitCh(c.Context):
+				if err != nil {
+					w.event(events.Trace{
+						ID:      w.ID(),
+						Message: "non-fatal token watcher error: " + err.Error(),
+					})
+				}
+			case new_raw_token := <-tokenUpdate:
+				if new_raw_token == raw_token {
+					continue
+				}
+				token, err := unpackToken(vault, new_raw_token, c.Unwrap)
+				switch err {
+				case nil:
+					raw_token = new_raw_token
+					vault.SetToken(token)
+					w.event(events.Trace{ // used with testing
+						ID:      w.ID(),
+						Message: "tokenfile token updated",
+					})
+				default:
+					w.event(events.Trace{
+						ID:      w.ID(),
+						Message: "non-fatal token watcher error: " + err.Error(),
+					})
+				}
+			case <-c.Context.Done():
+				return
+			}
+		}
+	}, nil
+}
+
+type vaultClient interface {
+	SetToken(string)
+	Logical() *api.Logical
+}
+
+// unpackToken grabs the real token from raw_token (unwrap, etc)
+func unpackToken(client vaultClient, token string, unwrap bool) (string, error) {
+	// If vault agent specifies wrap_ttl for the token it is returned as
+	// a SecretWrapInfo struct marshalled into JSON instead of the normal raw
+	// token. This checks for that and pulls out the token if it is the case.
+	var wrapinfo api.SecretWrapInfo
+	if err := json.Unmarshal([]byte(token), &wrapinfo); err == nil {
+		token = wrapinfo.Token
+	}
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return "", fmt.Errorf("empty token")
+	}
+
+	if unwrap {
+		client.SetToken(token) // needs to be set to unwrap
+		secret, err := client.Logical().Unwrap(token)
+		switch {
+		case err != nil:
+			return token, fmt.Errorf("vault unwrap: %s", err)
+		case secret == nil:
+			return token, fmt.Errorf("vault unwrap: no secret")
+		case secret.Auth == nil:
+			return token, fmt.Errorf("vault unwrap: no secret auth")
+		case secret.Auth.ClientToken == "":
+			return token, fmt.Errorf("vault unwrap: no token returned")
+		default:
+			token = secret.Auth.ClientToken
+		}
+	}
+	return token, nil
+}

--- a/vaulttoken/watcher_test.go
+++ b/vaulttoken/watcher_test.go
@@ -1,0 +1,306 @@
+package vaulttoken
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/hcat"
+	"github.com/hashicorp/hcat/dep"
+	"github.com/hashicorp/hcat/events"
+	"github.com/hashicorp/vault/api"
+)
+
+//type VaultTokenConfig struct {
+//	Token, VaultAgentTokenFile string
+//	UnwrapToken, RenewToken    bool
+//	RetryFunc                  hcat.RetryFunc
+//	clients                    *hcat.ClientSet
+//	doneCh                     chan struct{}
+//}
+
+// approle auto-auth setup in watch_test.go, TestMain()
+func TestVaultTokenWatcher(t *testing.T) {
+	// Don't set the below to run in parallel. They mess with the single
+	// running vault's permissions.
+	t.Run("noop", func(t *testing.T) {
+		conf := VaultTokenConfig{}
+		watcher, err := VaultTokenWatcher(conf)
+		if err != nil {
+			t.Error(err)
+		}
+		if watcher != nil {
+			t.Error("watcher should be nil")
+		}
+	})
+
+	t.Run("fixed_token", func(t *testing.T) {
+		testClients.Vault().SetToken(vaultToken)
+		conf := VaultTokenConfig{Clients: testClients}
+		conf.Token = vaultToken
+		watcher, err := VaultTokenWatcher(conf)
+		if err != nil {
+			t.Error(err)
+		}
+		if watcher != nil {
+			t.Error("watcher should be nil")
+		}
+		if testClients.Vault().Token() != vaultToken {
+			t.Error("Token should be " + vaultToken)
+		}
+	})
+
+	t.Run("secretwrapped_token", func(t *testing.T) {
+		testClients.Vault().SetToken("not a token")
+		defer testClients.Vault().SetToken(vaultToken)
+		conf := VaultTokenConfig{Clients: testClients}
+		data, err := json.Marshal(&api.SecretWrapInfo{Token: vaultToken})
+		if err != nil {
+			t.Error(err)
+		}
+		conf.Token = string(data)
+		_, err = VaultTokenWatcher(conf)
+		if err != nil {
+			t.Error(err)
+		}
+		if testClients.Vault().Token() != vaultToken {
+			t.Error("Token should be " + vaultToken)
+		}
+	})
+
+	t.Run("tokenfile", func(t *testing.T) {
+		// setup
+		testClients.Vault().SetToken(vaultToken)
+		tokenfile := runVaultAgent(testClients, tokenRoleId)
+		defer func() {
+			testClients.Vault().SetToken(vaultToken)
+			os.Remove(tokenfile)
+		}()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		/// XXX refactor out so I can use this below in TestVaultTokenRefreshToken
+		waitForUpdate := make(chan events.Trace)
+		tokenUpdateEvent := func(e events.Event) {
+			switch e := e.(type) {
+			case events.Trace:
+				// fmt.Printf("%#v\n", e) // in case of deadlock, uncomment
+				if e.Message == "tokenfile token updated" {
+					waitForUpdate <- e
+				}
+			}
+		}
+		/// XXX
+		conf := VaultTokenConfig{
+			Clients:      testClients,
+			Context:      ctx,
+			EventHandler: tokenUpdateEvent,
+		}
+		conf.Token = vaultToken
+		conf.AgentTokenFile = tokenfile
+
+		// test data
+		watcher, err := VaultTokenWatcher(conf)
+		if err != nil {
+			t.Error(err)
+		}
+		defer watcher.Stop()
+
+		// tests
+		<-waitForUpdate
+
+		if testClients.Vault().Token() == vaultToken {
+			t.Error("Token should not be " + vaultToken)
+		}
+	})
+
+	t.Run("renew", func(t *testing.T) {
+		// exercise the renewer: the action is all inside the vault api
+		// calls and vault so there's little to check.. so we just try
+		// to call it and make sure it doesn't error
+		testClients.Vault().SetToken(vaultToken)
+		renew := true
+		_, err := testClients.Vault().Auth().Token().Create(
+			&api.TokenCreateRequest{
+				ID:        "b_token",
+				TTL:       "1m",
+				Renewable: &renew,
+			})
+		if err != nil {
+			t.Error(err)
+		}
+		conf := VaultTokenConfig{Clients: testClients}
+		conf.Token = "b_token"
+		conf.Renew = renew
+		watcher, err := VaultTokenWatcher(conf)
+		if err != nil {
+			t.Error(err)
+		}
+		defer watcher.Stop()
+
+		select {
+		case err := <-watcher.WaitCh(context.Background()):
+			if err != nil {
+				t.Error(err)
+			}
+		case <-time.After(time.Millisecond * 100):
+			// give it a chance to throw an error
+		}
+	})
+}
+
+func TestVaultTokenRefreshToken(t *testing.T) {
+	zero := 0
+	waitForUpdate := make(chan events.Trace)
+	tokenUpdateEvent := func(e events.Event) {
+		switch e := e.(type) {
+		case events.Trace:
+			// fmt.Printf("%#v\n", e) // in case of deadlock, uncomment
+			if e.Message == "tokenfile token updated" {
+				waitForUpdate <- e
+			}
+		}
+	}
+	watcher := &vaultTokenWatcher{
+		Watcher: *hcat.NewWatcher(hcat.WatcherInput{
+			Clients: testClients,
+			// force watcher to be synchronous so we can control test flow
+			DataBufferSize: &zero,
+		}), event: tokenUpdateEvent,
+	}
+	wrapinfo := api.SecretWrapInfo{
+		Token: "btoken",
+	}
+	b, _ := json.Marshal(wrapinfo)
+	type testcase struct {
+		name, raw_token, exp_token string
+	}
+	vault := testClients.Vault()
+	testcases := []testcase{
+		{name: "noop", raw_token: "foo", exp_token: "foo"},
+		{name: "spaces", raw_token: " foo ", exp_token: "foo"},
+		{name: "secretwrap", raw_token: string(b), exp_token: "btoken"},
+	}
+	for i, tc := range testcases {
+		tc := tc // avoid for-loop pointer wart
+		name := fmt.Sprintf("%d_%s", i, tc.name)
+		t.Run(name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			conf := VaultTokenConfig{
+				Clients: testClients, Token: "non-blank", Context: ctx,
+			}
+			watchLoop, err := watchTokenFile(watcher, conf)
+			if err != nil {
+				t.Error(err)
+			}
+			go func() {
+				watchLoop()
+			}()
+			tokenUpdate <- tc.raw_token
+			// tests
+			<-waitForUpdate
+
+			if vault.Token() != tc.exp_token {
+				t.Errorf("bad token, expected: '%s', received '%s'",
+					tc.exp_token, vault.Token())
+			}
+		})
+	}
+	watcher.Stop()
+}
+
+// When vault-agent uses the wrap_ttl option it writes a json blob instead of
+// a raw token. This verifies it will extract the token from that when needed.
+// It doesn't test unwrap. The integration test covers that for now.
+func TestVaultTokenUnpackToken(t *testing.T) {
+	t.Run("table_test", func(t *testing.T) {
+		wrapinfo := api.SecretWrapInfo{
+			Token: "btoken",
+		}
+		b, _ := json.Marshal(wrapinfo)
+		testcases := []struct{ in, out string }{
+			{in: "", out: ""},
+			{in: "atoken", out: "atoken"},
+			{in: string(b), out: "btoken"},
+		}
+		for _, tc := range testcases {
+			dummy := &setTokenFaker{}
+			token, _ := unpackToken(dummy, tc.in, false)
+			if token != tc.out {
+				t.Errorf("unpackToken, wanted: '%v', got: '%v'", tc.out, token)
+			}
+		}
+	})
+	t.Run("unwrap_test", func(t *testing.T) {
+		vault := testClients.Vault()
+		vault.SetToken(vaultToken)
+		vault.SetWrappingLookupFunc(func(operation, path string) string {
+			if path == "auth/token/create" {
+				return "30s"
+			}
+			return ""
+		})
+		defer vault.SetWrappingLookupFunc(nil)
+
+		secret, err := vault.Auth().Token().Create(&api.TokenCreateRequest{
+			Lease: "1h",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		unwrap := true
+		wrappedToken := secret.WrapInfo.Token
+		token, err := unpackToken(vault, wrappedToken, unwrap)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if token == wrappedToken {
+			t.Errorf("tokens should not match")
+		}
+	})
+}
+
+type setTokenFaker struct {
+	Token string
+}
+
+func (t *setTokenFaker) SetToken(token string) {}
+func (t *setTokenFaker) Logical() *api.Logical { return nil }
+
+func fakedDepNotify(name string) fakeDep {
+	return fakeDep{name: name, data: make(chan string)}
+}
+
+type fakeDep struct {
+	name string
+	data chan string
+}
+
+func (d fakeDep) Send(s string) {
+	d.data <- s
+}
+
+// notifier interface (+ID)
+var _ hcat.Notifier = (*fakeDep)(nil)
+
+func (d fakeDep) Notify(_ any) bool {
+	return true
+}
+
+// dependency interface
+var _ dep.Dependency = (*fakeDep)(nil)
+
+func (d fakeDep) Fetch(dep.Clients) (interface{}, *dep.ResponseMetadata, error) {
+	s := <-d.data
+	return s, nil, nil
+}
+func (d fakeDep) ID() string     { return d.name }
+func (d fakeDep) String() string { return d.ID() }
+func (d fakeDep) Stop() {
+	close(d.data)
+}


### PR DESCRIPTION
Implemented as a stand alone watcher to monitor/manage the vault tokens. Ported over from consul-template version.
Everything works and has tests.